### PR TITLE
Add HTTPS when calling ipfs API

### DIFF
--- a/src/app/js/components/ipfs.js
+++ b/src/app/js/components/ipfs.js
@@ -4,7 +4,9 @@ import createReactClass from 'create-react-class'
 
 const host = (process.env.NODE_ENV !== 'production') ? 'localhost' : window.location.hostname
 const port = (process.env.NODE_ENV !== 'production') ? '5001' : (window.location.port || (window.location.protocol === 'https:' ? 443 : 80))
-const ipfs = require('ipfs-api')(host, port)
+const protocol = (process.env.NODE_ENV !== 'production') ? 'http' : (window.location.protocol === 'https:' ? 'https' : 'http')
+
+const ipfs = require('ipfs-api')(host, port, protocol)
 
 let version = ''
 let gateway = '//127.0.0.1:8080'


### PR DESCRIPTION
Hey,

I saw that when NODE_ENV is set to production, even if the site is on https, the call is made over http. Thsi PR fixes it, taking the protocol of the site to send the requests.

See #625 