### PR TITLE
chore: ensure consistent line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,12 +3,14 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 2
-trim_trailing_whitespace = true
-insert_final_newline = true
 end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
 
-# Tab indentation (no size specified)
 [Makefile]
 indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Adds editorconfig to keep our editors ending lines with LF and .gitattributes to get git to ensure LF line endings when the editor doesn't.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>