### PR TITLE
feat: truncate text and add tooltip on hover

### DIFF
--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -36,10 +36,10 @@ const File = (props) => {
         <Checkbox checked={selected} onChange={select} />
       </div>
       <div className='name flex items-center flex-grow-1 pa2 w-40'>
-        <div className='pointer dib icon' onClick={onNavigate}>
+        <div className='pointer dib icon flex-shrink-0' onClick={onNavigate}>
           <FileIcon name={name} type={type} />
         </div>
-        <span className='pointer' onClick={onNavigate}>{name}</span>
+        <span className='pointer truncate' onClick={onNavigate} title={name}>{name}</span>
       </div>
       <div className='status pa2 w-30'>{status}</div>
       <div className='size pa2 w-10'>{size}</div>

--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -6,45 +6,103 @@ import FileIcon from '../file-icon/FileIcon'
 import Status from '../status/Status'
 import './File.css'
 
-const File = (props) => {
-  let {selected, name, type, speed, status, size, onSelect, onNavigate, onCancel} = props
-
-  let className = 'File flex items-center bt pv2'
-
-  if (props.selected) {
-    className += ' selected'
-  }
-
-  if (status !== null) {
-    size = 'N/A'
-    status = <Status progress={status} cancel={onCancel} speed={speed} />
-  } else {
-    size = filesize(size)
-  }
-
-  if (type === 'directory') {
-    size = ''
-  }
-
-  const select = (select) => {
-    onSelect(name, select)
-  }
-
+const Tooltip = ({className = '', show, children, ...props}) => {
   return (
-    <div className={className}>
-      <div className='pa2 w2'>
-        <Checkbox checked={selected} onChange={select} />
-      </div>
-      <div className='name flex items-center flex-grow-1 pa2 w-40'>
-        <div className='pointer dib icon flex-shrink-0' onClick={onNavigate}>
-          <FileIcon name={name} type={type} />
-        </div>
-        <span className='pointer truncate' onClick={onNavigate} title={name}>{name}</span>
-      </div>
-      <div className='status pa2 w-30'>{status}</div>
-      <div className='size pa2 w-10'>{size}</div>
+    <div className={`nowrap white bg-navy-muted br2 pa1 f6 absolute ${show ? 'db' : 'dn'} ${className}`} {...props}>
+      <span style={{
+        width: '17px',
+        height: '17px',
+        transform: 'translate(-50%, -50%) rotate(45deg)',
+        borderRadius: '2px 0px 0px',
+        left: '50%',
+        zIndex: -1
+      }} className='db bg-navy-muted absolute' />
+      {children}
     </div>
   )
+}
+
+class File extends React.Component {
+  state = {
+    overflow: false,
+    displayTooltip: false
+  }
+
+  onResize = () => {
+    if (this.state.overflow !== (this.el.offsetWidth < this.el.scrollWidth)) {
+      this.setState((s) => ({ overflow: !s.overflow }))
+    }
+  }
+
+  onMouseOver = () => {
+    this.setState({ displayTooltip: true })
+  }
+
+  onMouseLeave = () => {
+    this.setState({ displayTooltip: false })
+  }
+
+  componentDidMount () {
+    window.addEventListener('resize', this.onResize)
+    this.onResize()
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.onResize)
+  }
+
+  render () {
+    let {selected, name, type, speed, status, size, onSelect, onNavigate, onCancel} = this.props
+
+    let className = 'File flex items-center bt pv2'
+
+    if (selected) {
+      className += ' selected'
+    }
+
+    if (status !== null) {
+      size = 'N/A'
+      status = <Status progress={status} cancel={onCancel} speed={speed} />
+    } else {
+      size = filesize(size)
+    }
+
+    if (type === 'directory') {
+      size = ''
+    }
+
+    const select = (select) => {
+      onSelect(name, select)
+    }
+
+    return (
+      <div className={className}>
+        <div className='pa2 w2'>
+          <Checkbox checked={selected} onChange={select} />
+        </div>
+        <div className='name relative flex items-center flex-grow-1 pa2 w-40'>
+          <div className='pointer dib icon flex-shrink-0' onClick={onNavigate}>
+            <FileIcon name={name} type={type} />
+          </div>
+          <span className='pointer truncate'
+            ref={(e) => { this.el = e }}
+            onClick={onNavigate}
+            onMouseOver={this.onMouseOver}
+            onMouseLeave={this.onMouseLeave}
+          >{name}</span>
+          { this.state.overflow &&
+            <Tooltip style={{
+              bottom: '-10px',
+              left: 'calc(50% + 1.125rem)',
+              transform: 'translateX(-50%)'
+            }} show={this.state.displayTooltip}>{name}</Tooltip>
+          }
+        </div>
+        <div className='status pa2 w-30'>{status}</div>
+        <div className='size pa2 w-10'>{size}</div>
+      </div>
+    )
+  }
 }
 
 File.propTypes = {


### PR DESCRIPTION
Truncates the text when it overflows and adds a tooltip on hover.

![localhost_3000_](https://user-images.githubusercontent.com/5447088/42442021-7f11e5ba-8361-11e8-92e4-e96a236f322e.png)

![localhost_3000_ 1](https://user-images.githubusercontent.com/5447088/42442023-805242da-8361-11e8-9ae7-5d24b9190d1f.png)
