### PR TITLE
fix: show total peers count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7107,8 +7107,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7126,13 +7125,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7145,18 +7142,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7259,8 +7253,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7270,7 +7263,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7283,20 +7275,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7313,7 +7302,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7386,8 +7374,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7397,7 +7384,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7473,8 +7459,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7504,7 +7489,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7522,7 +7506,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7561,13 +7544,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/peers/PeersPage.js
+++ b/src/peers/PeersPage.js
@@ -6,20 +6,21 @@ import { Helmet } from 'react-helmet'
 import WorldMap from './WorldMap/WorldMap'
 import PeersTable from './PeersTable/PeersTable'
 
-const PeersPage = ({ peerCoordinates, tableData }) => (
+const PeersPage = ({ peers, peerCoordinates, tableData }) => (
   <div data-id='PeersPage'>
     <Helmet>
       <title>Peers - IPFS</title>
     </Helmet>
 
     <div className='bg-snow-muted pa3'>
-      <WorldMap coordinates={peerCoordinates} />
+      <WorldMap peers={peers} coordinates={peerCoordinates} />
       <PeersTable peers={tableData} />
     </div>
   </div>
 )
 
 export default connect(
+  'selectPeers',
   'selectPeerCoordinates',
   'selectTableData',
   PeersPage

--- a/src/peers/WorldMap/WorldMap.js
+++ b/src/peers/WorldMap/WorldMap.js
@@ -10,6 +10,7 @@ import worldData from './world.json'
 
 export class WorldMap extends React.Component {
   static propTypes = {
+    peers: PropTypes.array,
     coordinates: PropTypes.array
   }
 
@@ -85,7 +86,7 @@ export class WorldMap extends React.Component {
   }
 
   render () {
-    const { coordinates } = this.props
+    const { peers, coordinates } = this.props
 
     return (
       <div className='flex w-100 mb4' style={{ 'height': '500px' }}>
@@ -94,7 +95,7 @@ export class WorldMap extends React.Component {
         </AutoSizer>
 
         <div className='flex flex-auto flex-column items-center self-end pb4'>
-          <div className='f1 gray'>{ coordinates ? coordinates.length : 0 }</div>
+          <div className='f1 gray'>{ peers ? peers.length : 0 }</div>
           <div className='f4 b'>PEERS</div>
         </div>
       </div>


### PR DESCRIPTION
The peers count (in the peers page) was only being showed when a specific peer resolved its location. 

Now it shows the connected peers from the get go and the map gets filled when the peers location becomes available.  