### PR TITLE
feat: share files link

### DIFF
--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -1,6 +1,6 @@
 import { join, dirname } from 'path'
 import { createSelector } from 'redux-bundler'
-import { getDownloadLink, filesToStreams } from '../lib/files'
+import { getDownloadLink, getShareableLink, filesToStreams } from '../lib/files'
 import ms from 'milliseconds'
 
 export const actions = {
@@ -238,6 +238,8 @@ export default (opts = {}) => {
       const gatewayUrl = store.selectGatewayUrl()
       return getDownloadLink(files, gatewayUrl, apiUrl, ipfs)
     }),
+
+    doFilesShareLink: make(actions.SHARE_LINK, async (ipfs, files) => getShareableLink(files, ipfs)),
 
     doFilesMove: make(actions.MOVE, (ipfs, src, dst) => ipfs.files.mv([src, dst])),
 

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -6,6 +6,8 @@ import Breadcrumbs from './breadcrumbs/Breadcrumbs'
 import FilesList from './files-list/FilesList'
 import FilePreview from './file-preview/FilePreview'
 import FileInput from './file-input/FileInput'
+import Overlay from '../components/overlay/Overlay'
+import ShareModal from './share-modal/ShareModal'
 import Errors from './errors/Errors'
 import downloadFile from './download-file'
 import { join } from 'path'
@@ -29,7 +31,11 @@ class FilesPage extends React.Component {
 
   state = {
     downloadAbort: null,
-    downloadProgress: null
+    downloadProgress: null,
+    share: {
+      isOpen: false,
+      link: ''
+    }
   }
 
   makeDir = (path) => this.props.doFilesMakeDir(join(this.props.files.path, path))
@@ -86,6 +92,24 @@ class FilesPage extends React.Component {
     doUpdateHash(`/explore/ipfs/${hash}`)
   }
 
+  share = async (files) => {
+    this.setState({
+      share: {
+        isOpen: true,
+        link: await this.props.doFilesShareLink(files)
+      }
+    })
+  }
+
+  closeShare = () => {
+    this.setState({
+      share: {
+        isOpen: false,
+        link: ''
+      }
+    })
+  }
+
   render () {
     const {
       files,
@@ -127,7 +151,7 @@ class FilesPage extends React.Component {
                 files={files.content}
                 upperDir={files.upper}
                 downloadProgress={this.state.downloadProgress}
-                onShare={() => window.alert('Sharing is not available, yet!')}
+                onShare={this.share}
                 onInspect={this.inspect}
                 onDownload={this.download}
                 onAddFiles={this.add}
@@ -140,6 +164,13 @@ class FilesPage extends React.Component {
             )}
           </div>
         }
+
+        <Overlay show={this.state.share.isOpen} onLeave={this.closeShare}>
+          <ShareModal
+            className='outline-0'
+            link={this.state.share.link}
+            onLeave={this.closeShare} />
+        </Overlay>
       </div>
     )
   }
@@ -152,6 +183,7 @@ export default connect(
   'doFilesWrite',
   'doFilesAddPath',
   'doFilesDownloadLink',
+  'doFilesShareLink',
   'doFilesMakeDir',
   'doFilesFetch',
   'doFilesDismissErrors',

--- a/src/files/share-modal/ShareModal.js
+++ b/src/files/share-modal/ShareModal.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ShareIcon from '../../icons/StrokeShare'
+import Button from '../../components/button/Button'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
+import { Modal, ModalActions, ModalBody } from '../../components/modal/Modal'
+
+const ShareModal = ({onLeave, link, className, ...props}) => {
+
+  return (
+    <Modal {...props} className={className} onCancel={onLeave} >
+      <ModalBody title='Share Files' icon={ShareIcon}>
+        <p className='gray w-80 center'>
+          Copy the link below and share it with your friends.
+        </p>
+
+        <div className='flex center w-100 pa2'>
+          <input
+            value={link}
+            readOnly
+            autoFocus
+            className={`input-reset flex-grow-1 charcoal-muted ba b--black-20 pa2 mr2 focus-outline`}
+            type='text' />
+        </div>
+      </ModalBody>
+
+      <ModalActions>
+        <Button className='ma2' bg='bg-gray' onClick={onLeave}>Close</Button>
+        <CopyToClipboard text={link}>
+          <Button className='ma2'>Copy</Button>
+        </CopyToClipboard>
+      </ModalActions>
+    </Modal>
+  )
+}
+
+ShareModal.propTypes = {
+  onLeave: PropTypes.func.isRequired,
+  link: PropTypes.string
+}
+
+ShareModal.defaultProps = {
+  className: ''
+}
+
+export default ShareModal

--- a/src/files/share-modal/ShareModal.js
+++ b/src/files/share-modal/ShareModal.js
@@ -26,7 +26,7 @@ const ShareModal = ({onLeave, link, className, ...props}) => {
 
       <ModalActions>
         <Button className='ma2' bg='bg-gray' onClick={onLeave}>Close</Button>
-        <CopyToClipboard text={link}>
+        <CopyToClipboard text={link} onCopy={onLeave}>
           <Button className='ma2'>Copy</Button>
         </CopyToClipboard>
       </ModalActions>

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -43,7 +43,7 @@ async function downloadSingle (file, gatewayUrl, apiUrl) {
   return { url, filename }
 }
 
-export async function makeLinkFromFiles (files, ipfs) {
+export async function makeHashFromFiles (files, ipfs) {
   let node = await ipfs.object.new('unixfs-dir')
 
   for (const file of files) {
@@ -63,7 +63,7 @@ async function downloadMultiple (files, apiUrl, ipfs) {
     return Promise.reject(e)
   }
 
-  const multihash = await makeLinkFromFiles(files, ipfs)
+  const multihash = await makeHashFromFiles(files, ipfs)
 
   return {
     url: `${apiUrl}/api/v0/get?arg=${multihash}&archive=true&compress=true`,
@@ -77,4 +77,16 @@ export async function getDownloadLink (files, gatewayUrl, apiUrl, ipfs) {
   }
 
   return downloadMultiple(files, apiUrl, ipfs)
+}
+
+export async function getShareableLink (files, ipfs) {
+  let hash
+
+  if (files.length === 1) {
+    hash = files[0].hash
+  } else {
+    hash = await makeHashFromFiles(files, ipfs)
+  }
+
+  return `https://ipfs.io/ipfs/${hash}`
 }


### PR DESCRIPTION
When you hit share, you'll get a modal like this:

![image](https://user-images.githubusercontent.com/5447088/43518865-4b5b329a-9585-11e8-9b12-81b46ea2849b.png)

When @fsdiogo has the new sharing/downloading page finished, we can change it to something like `https://share.ipfs.io/#QmHash`.