### PR TITLE
[wip] dial down the redux actions

### DIFF
--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -1,3 +1,4 @@
+import Cid from 'cids'
 import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
 import { resolveIpldPath, quickSplitPath } from '../lib/path'
 
@@ -7,37 +8,64 @@ const bundle = createAsyncResourceBundle({
   actionBaseType: 'EXPLORE',
   getPromise: async (args) => {
     const {store, getIpfs} = args
-    const hash = store.selectHash()
-    let path = decodeURIComponent(hash.replace('/explore', ''))
+    let path = store.selectExplorePathFromHash()
     if (!path) return null
-    const {cidOrFqdn, rest} = quickSplitPath(path)
-    const {targetNode, canonicalPath, localPath, nodes, pathBoundaries} = await resolveIpldPath(getIpfs, cidOrFqdn, rest)
-    return {
-      path,
-      targetNode,
-      canonicalPath,
-      localPath,
-      nodes,
-      pathBoundaries
+    const pathParts = quickSplitPath(path)
+    if (!pathParts) return null
+    const {cidOrFqdn, rest} = pathParts
+    try {
+      // TODO: handle ipns, which would give us a fqdn in the cid position.
+      const cid = new Cid(cidOrFqdn)
+      const {
+        targetNode,
+        canonicalPath,
+        localPath,
+        nodes,
+        pathBoundaries
+      } = await resolveIpldPath(getIpfs, cid.toBaseEncodedString(), rest)
+
+      return {
+        path,
+        targetNode,
+        canonicalPath,
+        localPath,
+        nodes,
+        pathBoundaries
+      }
+    } catch (error) {
+      console.log('Failed to resolve path', path, error)
+      return { path, error }
     }
   },
   staleAfter: Infinity,
   checkIfOnline: false
 })
 
+bundle.selectExplorePathFromHash = createSelector(
+  'selectRouteInfo',
+  (routeInfo) => {
+    if (!routeInfo.url.startsWith('/explore')) return
+    if (!routeInfo.params.path) return
+    return decodeURIComponent(routeInfo.params.path)
+  }
+)
+
 // Fetch the explore data when the address in the url hash changes.
 bundle.reactExploreFetch = createSelector(
+  'selectIpfsReady',
   'selectExploreIsLoading',
   'selectExploreIsWaitingToRetry',
-  'selectIpfsReady',
-  'selectRouteInfo',
+  'selectExplorePathFromHash',
   'selectExplore',
-  (isLoading, isWaitingToRetry, ipfsReady, {url, params}, obj) => {
-    if (!isLoading && !isWaitingToRetry && ipfsReady && url.startsWith('/explore')) {
-      if (!obj || obj.path !== params.path) {
-        return { actionCreator: 'doFetchExplore' }
-      }
-    }
+  (ipfsReady, isLoading, isWaitingToRetry, explorePathFromHash, obj) => {
+    // Wait for ipfs or the pending request to complete
+    if (!ipfsReady || isLoading || isWaitingToRetry) return false
+    // Theres no url path and no data so nothing to do.
+    if (!explorePathFromHash && !obj) return false
+    // We already have the data for the path.
+    if (obj && explorePathFromHash === obj.path) return false
+
+    return { actionCreator: 'doFetchExplore' }
   }
 )
 

--- a/src/bundles/peer-bandwidth.js
+++ b/src/bundles/peer-bandwidth.js
@@ -16,9 +16,9 @@ export default function (opts) {
   // This implies a loose dependency on an idle action dispatcher that'll fire
   // if no other actions are fired within a certain time period. e.g. the
   // APP_IDLE action that is dispatched from the reactor bundle.
-  opts.tickResolution = opts.tickResolution || 1000
+  opts.tickResolution = opts.tickResolution || 5000
   // The minimum time between updates for each peer
-  opts.peerUpdateInterval = opts.peerUpdateInterval || 5000
+  opts.peerUpdateInterval = opts.peerUpdateInterval || 10000
   // Inactive peers are de-prioritised
   opts.inactivePeerUpdateInterval = opts.inactivePeerUpdateInterval || 30000
 

--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -8,7 +8,7 @@ import ms from 'milliseconds'
 export default function (opts) {
   opts = opts || {}
   // Max number of locations to retrieve concurrently
-  opts.concurrency = opts.concurrency || 10
+  opts.concurrency = opts.concurrency || 5
   // Cache options
   opts.cache = opts.cache || {}
 
@@ -203,8 +203,9 @@ export default function (opts) {
       'selectPeerLocationsRaw',
       'selectPeerLocationsQueuingPeers',
       'selectPeerLocationsResolvingPeers',
-      (ipfsReady, peerLocationsRaw, queuingPeers, resolvingPeers) => {
-        if (ipfsReady && queuingPeers.length && resolvingPeers.length < opts.concurrency) {
+      'selectHash',
+      (ipfsReady, peerLocationsRaw, queuingPeers, resolvingPeers, hash) => {
+        if (ipfsReady && queuingPeers.length && resolvingPeers.length < opts.concurrency && hash === '/peers') {
           const peerId = queuingPeers[0]
           const locsByAddr = peerLocationsRaw[peerId]
 


### PR DESCRIPTION
Only fire peer-locations events on the peer page.
Upgrade explore bundle to fix react loop on home page.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>