### PR TITLE
refactor: simplify file adding

### DIFF
--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -240,6 +240,11 @@ export default (opts = {}) => {
         progress: updateProgress
       })
 
+      if (res.length !== streams.length + 1) {
+        // See https://github.com/ipfs/js-ipfs-api/issues/797
+        throw new Error('Unable to finish upload: IPFS API returned a partial response. Try adding a smaller tree.')
+      }
+
       for (const { path, hash } of res) {
         // Only go for direct children
         if (path.indexOf('/') === -1 && path !== '') {

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -66,7 +66,13 @@ class FileList extends React.Component {
 
   get selectedMenu () {
     const unselectAll = () => this.toggleAll(false)
-    const size = this.selectedFiles.reduce((a, b) => a + (b.size || b.cumulativeSize), 0)
+    const size = this.selectedFiles.reduce((a, b) => {
+      if (b.cumulativeSize) {
+        return a + b.cumulativeSize
+      }
+
+      return a + b.size
+    }, 0)
     const show = this.state.selected.length !== 0
 
     return (

--- a/src/lib/dnd-backend.js
+++ b/src/lib/dnd-backend.js
@@ -25,7 +25,7 @@ async function scanFiles (item, root = '') {
     const file = await getFileFromEntry(item)
 
     return [{
-      name: join(root, file.webkitRelativePath || file.name),
+      path: join(root, file.webkitRelativePath || file.name),
       content: fileReader(file),
       size: file.size
     }]
@@ -51,13 +51,13 @@ async function scan (files) {
     if (file.getAsEntry || file.webkitGetAsEntry) {
       entries.push({
         entry: getAsEntry(file),
-        name: file.name
+        path: file.name
       })
     } else {
       totalSize += file.size
 
       streams.push({
-        name: file.webkitRelativePath || file.name,
+        path: file.webkitRelativePath || file.name,
         content: fileReader(file),
         size: file.size
       })

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -28,7 +28,7 @@ export async function filesToStreams (files) {
     }
 
     streams.push({
-      name: file.webkitRelativePath || file.name,
+      path: file.webkitRelativePath || file.name,
       content: stream,
       size: file.size
     })


### PR DESCRIPTION
@lidel with your comment yesterday (https://github.com/ipfs-shipyard/ipfs-webui/issues/762#issuecomment-416643973) I ended up changing the code and simplifying it a bit.

Although, it happened once or twice to upload like 10 streams and it would only return 1 hash which I think it might be related to https://github.com/ipfs/js-ipfs-api/issues/797!

It also happened before, but since it was only one by one, they wouldn't all fail.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>