### PR TITLE
feat: suggest download when preview not possible

### DIFF
--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -37,8 +37,8 @@ class FilesPreview extends React.Component {
       case 'pdf':
         return (
           <object width='100%' height='500px' data={src} type='application/pdf'>
-            If you're seeing this, is because your browser doesn't support previwing
-            PDF files.
+            Your browser does not support PDFs. Please download the PDF to view it:
+            <a href={src} download target='_blank' className='underline-hover navy-muted'>Download PDF</a>.
           </object>
         )
       case 'video':
@@ -51,8 +51,9 @@ class FilesPreview extends React.Component {
         return <img className={className} alt={stats.name} src={src} />
       default:
         const cantPreview = (
-          <div className='b'>
-            Sorry, this file can't be previewed <span role='img' aria-label='sad'>😢</span>
+          <div>
+            <p className='b'>Sorry, this file can't be previewed <span role='img' aria-label='sad'>😢</span></p>
+            <p>Try <a href={src} download target='_blank' className='underline-hover navy-muted' >downloading</a> it instead.</p>
           </div>
         )
 

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -53,7 +53,7 @@ class FilesPreview extends React.Component {
         const cantPreview = (
           <div>
             <p className='b'>Sorry, this file can't be previewed <span role='img' aria-label='sad'>😢</span></p>
-            <p>Try <a href={src} download target='_blank' className='underline-hover navy-muted' >downloading</a> it instead.</p>
+            <p>Try <a href={src} download target='_blank' className='link blue' >downloading</a> it instead.</p>
           </div>
         )
 


### PR DESCRIPTION
If something goes wrong, we should try providing the next action user can pick.
In case of being unable to see the preview, people will appreciate an option of direct download without the need for going back to file list.

This PR adds a plain text link, but the UI can be improved in separate PRs:

![screenshot](https://user-images.githubusercontent.com/157609/44786474-8c2bf280-ab94-11e8-8aa3-cec1313ae910.png)
