### PR TITLE
feat: start bandwidth graph at 1 Mb/s

### DIFF
--- a/src/status/NodeBandwidthChart.js
+++ b/src/status/NodeBandwidthChart.js
@@ -6,7 +6,7 @@ import filesize from 'filesize'
 import { Title } from './Commons'
 import Box from '../components/box/Box'
 
-const humansize = filesize.partial({ round: 0 })
+const humansize = filesize.partial({ round: 1, bits: true })
 
 export class NodeBandwidthChart extends Component {
   static propTypes = {
@@ -52,7 +52,8 @@ export class NodeBandwidthChart extends Component {
         yAxes: [{
           stacked: true,
           ticks: {
-            callback: v => humansize(v) + '/s'
+            callback: v => humansize(v) + '/s',
+            suggestedMax: 125000
           }
         }]
       },


### PR DESCRIPTION
The bandwidth graph now has the minimum range set to 0 - 1 Mb/s.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>