### PR TITLE
feat: set config editor height from content

### DIFF
--- a/src/settings/editor/JsonEditor.js
+++ b/src/settings/editor/JsonEditor.js
@@ -7,6 +7,8 @@ import './theme/ipfs_dark'
 class JsonEditor extends React.Component {
   render () {
     const { value, readOnly, onChange } = this.props
+    const lineHeight = 16
+    const height = Math.max(500, value.split('\n').length * lineHeight)
     return (
       <div className='pv3 bg-navy br2'>
         <AceEditor
@@ -16,7 +18,7 @@ class JsonEditor extends React.Component {
           mode='json'
           theme='ipfs_dark'
           width='100%'
-          height='2100px'
+          height={height + 'px'}
           fontSize={12}
           showPrintMargin={false}
           showGutter


### PR DESCRIPTION
Calculate the editor height from the number of lines in the config file.

<img width="1552" alt="screenshot 2018-09-13 15 47 29" src="https://user-images.githubusercontent.com/58871/45496194-cc7e9980-b76c-11e8-82ab-a87a3b95c29b.png">


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>