### PR TITLE
feat: make the peers map fast

### DIFF
--- a/src/bundles/peers.js
+++ b/src/bundles/peers.js
@@ -10,7 +10,7 @@ const bundle = createAsyncResourceBundle({
   checkIfOnline: false
 })
 
-bundle.selectTableData = createSelector(
+bundle.selectPeersTableData = createSelector(
   'selectPeers',
   'selectPeerLocations',
   (peers, locations) => peers && peers.map((peer, idx) => {

--- a/src/bundles/stats.js
+++ b/src/bundles/stats.js
@@ -3,21 +3,17 @@ import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
 const bundle = createAsyncResourceBundle({
   name: 'stats',
   getPromise: async ({ getIpfs }) => {
-    const [bitswap, repo, bw] = await Promise.all([
-      getIpfs().stats.bitswap(),
-      getIpfs().stats.repo(),
+    const [bw] = await Promise.all([
+      // getIpfs().stats.bitswap(),
+      // getIpfs().stats.repo(),
       getIpfs().stats.bw()
     ])
-    return { bitswap, repo, bw }
+    return { bw }
   },
-  staleAfter: 2000,
+  staleAfter: 3000,
   persist: false,
   checkIfOnline: false
 })
-
-bundle.selectWantlistLength = (state) => {
-  return (state.stats.bitswap && state.stats.bitswap.wantlist && state.stats.bitswap.wantlist.length) || 0
-}
 
 // Fetch the config if we don't have it or it's more than `staleAfter` ms old
 bundle.reactStatsFetch = createSelector(

--- a/src/peers/PeersPage.js
+++ b/src/peers/PeersPage.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { connect } from 'redux-bundler-react'
 import { Helmet } from 'react-helmet'
 import { translate } from 'react-i18next'
 
@@ -8,21 +7,16 @@ import Box from '../components/box/Box'
 import WorldMap from './WorldMap/WorldMap'
 import PeersTable from './PeersTable/PeersTable'
 
-const PeersPage = ({ t, peers, peerCoordinates, tableData }) => (
+const PeersPage = ({ t }) => (
   <div data-id='PeersPage'>
     <Helmet>
       <title>{t('title')} - IPFS</title>
     </Helmet>
     <Box className='pa3'>
-      <WorldMap peers={peers} coordinates={peerCoordinates} />
-      <PeersTable peers={tableData} />
+      <WorldMap />
+      <PeersTable />
     </Box>
   </div>
 )
 
-export default connect(
-  'selectPeers',
-  'selectPeerCoordinates',
-  'selectTableData',
-  translate('peers')(PeersPage)
-)
+export default translate('peers')(PeersPage)

--- a/src/peers/PeersTable/PeersTable.js
+++ b/src/peers/PeersTable/PeersTable.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'redux-bundler-react'
 import { translate } from 'react-i18next'
 import { Table, Column, AutoSizer } from 'react-virtualized'
 import CountryFlag from 'react-country-flag'
@@ -7,7 +8,7 @@ import Address from '../../components/address/Address'
 
 export class PeersTable extends React.Component {
   static propTypes = {
-    peers: PropTypes.array,
+    peersTableData: PropTypes.array,
     t: PropTypes.func.isRequired
   }
 
@@ -40,12 +41,12 @@ export class PeersTable extends React.Component {
   }
 
   render () {
-    const { peers, t } = this.props
+    const { peersTableData, t } = this.props
     const tableHeight = 320
 
     return (
       <div className='flex w-100 bg-white-70' style={{ 'height': `${tableHeight}px` }}>
-        { peers && <AutoSizer>
+        { peersTableData && <AutoSizer>
           {({ width }) => (
             <Table
               className='tl fw4 w-100 f7'
@@ -55,8 +56,8 @@ export class PeersTable extends React.Component {
               height={tableHeight}
               headerHeight={32}
               rowHeight={32}
-              rowCount={peers.length}
-              rowGetter={({ index }) => peers[index]}>
+              rowCount={peersTableData.length}
+              rowGetter={({ index }) => peersTableData[index]}>
               <Column label={t('peerId')} dataKey='id' width={430} className='charcoal monospace pl2 truncate f7' />
               <Column label={t('address')} cellRenderer={this.addressCellRenderer} dataKey='address' width={280} className='pl2' />
               <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={220} className='pl2 f6 navy-muted b truncate' />
@@ -68,4 +69,7 @@ export class PeersTable extends React.Component {
   }
 }
 
-export default translate('peers')(PeersTable)
+export default connect(
+  'selectPeersTableData',
+  translate('peers')(PeersTable)
+)

--- a/src/peers/WorldMap/WorldMap.js
+++ b/src/peers/WorldMap/WorldMap.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import ReactFauxDOM from 'react-faux-dom'
+import { connect } from 'redux-bundler-react'
 import { AutoSizer } from 'react-virtualized'
 import { translate } from 'react-i18next'
 import * as d3 from 'd3'
@@ -9,100 +9,118 @@ import * as topojson from 'topojson'
 // Static
 import worldData from './world.json'
 
-export class WorldMap extends React.Component {
-  static propTypes = {
-    peers: PropTypes.array,
-    coordinates: PropTypes.array
-  }
-
-  renderMap = (height, width, coordinates) => {
-    // https://github.com/d3/d3-geo/blob/master/README.md#geoEquirectangular
-    const projection = d3.geoEquirectangular()
-      .scale(height / Math.PI)
-      .translate([width / 2, height / 2])
-      .precision(0.1)
-
-    // https://github.com/d3/d3-geo/blob/master/README.md#paths
-    const path = d3.geoPath().projection(projection)
-
-    // https://github.com/d3/d3-geo/blob/master/README.md#geoGraticule
-    const graticule = d3.geoGraticule()
-
-    const el = d3.select(ReactFauxDOM.createElement('svg'))
-      .attr('width', width)
-      .attr('height', height)
-
-    // Fill Pattern
-    el.append('defs')
-      .append('pattern')
-      .attr('id', 'gridpattern')
-      .attr('x', 0)
-      .attr('y', 0)
-      .attr('width', 5)
-      .attr('height', 5)
-      .attr('patternUnits', 'userSpaceOnUse')
-      .append('circle')
-      .attr('cx', 3)
-      .attr('cy', 3)
-      .attr('r', 1)
-      .attr('fill', '#AAA')
-      .attr('stroke', '#DDD')
-
-    el.append('path')
-      .datum(graticule)
-      .attr('class', 'graticule')
-      .attr('d', path)
-
-    el.insert('path', '.graticule')
-      .datum(topojson.feature(worldData, worldData.objects.land))
-      .attr('d', path)
-      .attr('fill', 'url(#gridpattern)')
-
-    el.insert('path', '.graticule')
-      .datum(topojson.mesh(
-        worldData,
-        worldData.objects.countries,
-        (a, b) => a !== b
-      ))
-      .attr('d', path)
-      .attr('fill', 'none')
-      .attr('stroke', 'none')
-
-    el.append('path')
-      .datum({
-        type: 'MultiPoint',
-        coordinates: coordinates
-      })
-      .attr('d', path.pointRadius((d) => 10))
-      .attr('fill', 'rgba(93, 213, 218, 0.4)')
-
-    el.append('path')
-      .datum({
-        type: 'MultiPoint',
-        coordinates: coordinates
-      })
-      .attr('d', path.pointRadius((d) => 3))
-      .attr('fill', 'rgb(93, 213, 218)')
-
-    return el.node().toReact()
-  }
-
-  render () {
-    const { t, peers, coordinates } = this.props
-
-    return (
-      <div className='flex w-100 mb4' style={{ 'height': '550px' }}>
-        <AutoSizer>
-          { ({ height, width }) => this.renderMap(height, width, coordinates) }
-        </AutoSizer>
-
-        <div className='flex flex-auto flex-column items-center self-end pb5'>
-          <div className='f1 fw5 aqua'>{ peers ? peers.length : 0 }</div>
-          <div className='f4 b ttu'>{t('peers')}</div>
-        </div>
+const WorldMap = ({ t }) => {
+  return (
+    <div className='flex w-100 mb4' style={{ 'height': '550px' }}>
+      <AutoSizer>
+        { ({ height, width }) => (
+          <GeoPath width={width} height={height}>
+            { ({ path }) => (
+              <div className='relative'>
+                <Map height={height} width={width} path={path} />
+                <div className='absolute top-0'>
+                  <MapPins height={height} width={width} path={path} />
+                </div>
+              </div>
+            )}
+          </GeoPath>
+        )}
+      </AutoSizer>
+      <div className='flex flex-auto flex-column items-center self-end pb5'>
+        <div className='f1 fw5 aqua'><PeersCount /></div>
+        <div className='f4 b ttu'>{t('peers')}</div>
       </div>
-    )
-  }
+    </div>
+  )
 }
+
+const PeersCount = connect('selectPeers', ({ peers }) => peers ? peers.length : 0)
+
+const GeoPath = ({ width, height, children }) => {
+  // https://github.com/d3/d3-geo/blob/master/README.md#geoEquirectangular
+  const projection = d3.geoEquirectangular()
+    .scale(height / Math.PI)
+    .translate([width / 2, height / 2])
+    .precision(0.1)
+  // https://github.com/d3/d3-geo/blob/master/README.md#paths
+  const path = d3.geoPath().projection(projection)
+
+  return children({ path })
+}
+
+// Earth! It's complicated, so try not to re-render so much
+const Map = ({ width, height, path }) => {
+  // https://github.com/d3/d3-geo/blob/master/README.md#geoGraticule
+  const graticule = d3.geoGraticule()
+
+  const el = d3.select(ReactFauxDOM.createElement('svg'))
+    .attr('width', width)
+    .attr('height', height)
+
+  // Fill Pattern
+  el.append('defs')
+    .append('pattern')
+    .attr('id', 'gridpattern')
+    .attr('x', 0)
+    .attr('y', 0)
+    .attr('width', 5)
+    .attr('height', 5)
+    .attr('patternUnits', 'userSpaceOnUse')
+    .append('circle')
+    .attr('cx', 3)
+    .attr('cy', 3)
+    .attr('r', 1)
+    .attr('fill', '#AAA')
+    .attr('stroke', '#DDD')
+
+  el.append('path')
+    .datum(graticule)
+    .attr('class', 'graticule')
+    .attr('d', path)
+
+  el.insert('path', '.graticule')
+    .datum(topojson.feature(worldData, worldData.objects.land))
+    .attr('d', path)
+    .attr('fill', 'url(#gridpattern)')
+
+  el.insert('path', '.graticule')
+    .datum(topojson.mesh(
+      worldData,
+      worldData.objects.countries,
+      (a, b) => a !== b
+    ))
+    .attr('d', path)
+    .attr('fill', 'none')
+    .attr('stroke', 'none')
+
+  return el.node().toReact()
+}
+
+// Just the dots on the map, this gets called a lot.
+const MapPins = connect('selectPeerCoordinates', ({ width, height, path, peerCoordinates }) => {
+  // https://github.com/d3/d3-geo/blob/master/README.md#geoGraticule
+  // const graticule = d3.geoGraticule()
+  const el = d3.select(ReactFauxDOM.createElement('svg'))
+    .attr('width', width)
+    .attr('height', height)
+
+  el.append('path')
+    .datum({
+      type: 'MultiPoint',
+      coordinates: peerCoordinates
+    })
+    .attr('d', path.pointRadius((d) => 8))
+    .attr('fill', 'rgba(93, 213, 218, 0.4)')
+
+  el.append('path')
+    .datum({
+      type: 'MultiPoint',
+      coordinates: peerCoordinates
+    })
+    .attr('d', path.pointRadius((d) => 3))
+    .attr('fill', 'rgb(93, 213, 218)')
+
+  return el.node().toReact()
+})
 
 export default translate('peers')(WorldMap)


### PR DESCRIPTION
- Split out the world rendering from the pins rendering.
- Stop asking ipfs for stats we're not using.
- Ask for stats less often

| Before  | After  |
|-------- |------ |
| ![peer-map-before](https://user-images.githubusercontent.com/58871/45649586-a8e88580-bac3-11e8-93c8-6ca28884da7f.gif) | ![peer-map-after](https://user-images.githubusercontent.com/58871/45649597-af76fd00-bac3-11e8-89e8-599e5dc64a4d.gif) |

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>