### PR TITLE
feat: add footer with code and bugs links

### DIFF
--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -22,5 +22,7 @@
   "totalOut": "Total Out",
   "more": "...and {count} more",
   "in": "In",
-  "out": "Out"
+  "out": "Out",
+  "codeLink": "See the code",
+  "bugsLink": "Report a bug"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -26,12 +26,12 @@ export class App extends Component {
   }
 
   render () {
-    const { route: Page, ipfsReady, routeInfo: { url } } = this.props
+    const { route: Page, ipfsReady, routeInfo: { url }, navbarWidth } = this.props
 
     return (
       <div className='sans-serif' onClick={navHelper(this.props.doUpdateUrl)}>
         <div className='flex' style={{ minHeight: '100vh' }}>
-          <div className='flex-none bg-navy'>
+          <div className='flex-none bg-navy' style={{ width: navbarWidth }}>
             <NavBar />
           </div>
           <div className='flex-auto'>
@@ -59,6 +59,7 @@ export class App extends Component {
 
 export default connect(
   'selectRoute',
+  'selectNavbarWidth',
   'selectRouteInfo',
   'doUpdateUrl',
   'doInitIpfs',

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Footer = ({
+  t,
+  codeUrl,
+  bugsUrl = `${codeUrl}/issues`
+}) => {
+  return (
+    <footer className='flex justify-between pv2 bt b--silver'>
+      <a href={codeUrl} className='flex-none link glow o-70 f6 charcoal'>
+        <svg className='fill-current-color v-mid' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='16' height='16'><path d='M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z ' /></svg>
+        <span className='ph1'>{t('codeLink')}</span>
+      </a>
+      <a href={bugsUrl} className='flex-none link glow o-70 f6 charcoal'>
+        <span className='ph1'>{t('bugsLink')}</span>
+        <svg className='fill-current-color v-mid' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='16' height='16'><path d='M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49 0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z ' /></svg>
+      </a>
+    </footer>
+  )
+}
+
+Footer.propTypes = {
+  codeUrl: PropTypes.string.isRequired,
+  bugsUrl: PropTypes.string
+}
+
+export default Footer

--- a/src/components/footer/Footer.stories.js
+++ b/src/components/footer/Footer.stories.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import i18n from '../../i18n'
+import Footer from './Footer.js'
+
+storiesOf('Footer', module)
+  .add('default', () => (
+    <div className='sans-serif' style={{ padding: 10 }}>
+      <Footer codeUrl='https://github.com/ipfs-shipyard/ipld-explorer-components' t={i18n.getFixedT('en', 'status')} />
+    </div>
+  ))

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -50,20 +50,22 @@ export const NavBar = ({ t, isSettingsEnabled, width, open, onToggle }) => {
   const bugsUrl = `${codeUrl}/issues`
 
   return (
-    <div id='navbar' style={{ width }}>
-      <div className='pointer' style={{ paddingTop: 35 }} onClick={onToggle}>
-        <img className='center' style={{ height: 70, display: open ? 'block' : 'none' }} src={ipfsLogoText} alt='IPFS' title='Toggle navbar' />
-        <img className='center' style={{ height: 70, display: open ? 'none' : 'block' }} src={ipfsLogo} alt='IPFS' title='Toggle navbar' />
+    <div id='navbar' className='h-100 fixed flex flex-column justify-between' style={{ width }}>
+      <div className='flex flex-column'>
+        <div className='pointer' style={{ paddingTop: 35 }} onClick={onToggle}>
+          <img className='center' style={{ height: 70, display: open ? 'block' : 'none' }} src={ipfsLogoText} alt='IPFS' title='Toggle navbar' />
+          <img className='center' style={{ height: 70, display: open ? 'none' : 'block' }} src={ipfsLogo} alt='IPFS' title='Toggle navbar' />
+        </div>
+        <nav className='db pt4' role='menubar'>
+          <NavLink to='/' exact icon={StrokeMarketing} open={open}>{t('status:title')}</NavLink>
+          <NavLink to='/files/' icon={StrokeWeb} open={open}>{t('files:title')}</NavLink>
+          <NavLink to='/explore' icon={StrokeIpld} open={open}>{t('explore:tabName')}</NavLink>
+          <NavLink to='/peers' icon={StrokeCube} open={open}>{t('peers:title')}</NavLink>
+          <NavLink to='/settings' icon={StrokeSettings} disabled={!isSettingsEnabled} open={open}>{t('settings:title')}</NavLink>
+        </nav>
       </div>
-      <nav className='db pt4' role='menubar'>
-        <NavLink to='/' exact icon={StrokeMarketing} open={open}>{t('status:title')}</NavLink>
-        <NavLink to='/files/' icon={StrokeWeb} open={open}>{t('files:title')}</NavLink>
-        <NavLink to='/explore' icon={StrokeIpld} open={open}>{t('explore:tabName')}</NavLink>
-        <NavLink to='/peers' icon={StrokeCube} open={open}>{t('peers:title')}</NavLink>
-        <NavLink to='/settings' icon={StrokeSettings} disabled={!isSettingsEnabled} open={open}>{t('settings:title')}</NavLink>
-      </nav>
       { open &&
-      <div className='mt5 flex flex-colum justify-center'>
+      <div className='mb3 flex flex-colum justify-center'>
         <a className='link white f6 o-50 glow' href={codeUrl} target='_blank'>{t('status:codeLink')}</a>
         <span className='mh2 white f6 o-50'>|</span>
         <a className='link white f6 o-50 glow' href={bugsUrl} target='_blank'>{t('status:bugsLink')}</a>

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -45,21 +45,32 @@ const NavLink = ({
   )
 }
 
-export const NavBar = ({ t, isSettingsEnabled, width, open, onToggle }) => (
-  <div id='navbar' style={{ width }}>
-    <div className='pointer' style={{ paddingTop: 35 }} onClick={onToggle}>
-      <img className='center' style={{ height: 70, display: open ? 'block' : 'none' }} src={ipfsLogoText} alt='IPFS' title='Toggle navbar' />
-      <img className='center' style={{ height: 70, display: open ? 'none' : 'block' }} src={ipfsLogo} alt='IPFS' title='Toggle navbar' />
+export const NavBar = ({ t, isSettingsEnabled, width, open, onToggle }) => {
+  const codeUrl = 'https://github.com/ipfs-shipyard/ipfs-webui'
+  const bugsUrl = `${codeUrl}/issues`
+
+  return (
+    <div id='navbar' style={{ width }}>
+      <div className='pointer' style={{ paddingTop: 35 }} onClick={onToggle}>
+        <img className='center' style={{ height: 70, display: open ? 'block' : 'none' }} src={ipfsLogoText} alt='IPFS' title='Toggle navbar' />
+        <img className='center' style={{ height: 70, display: open ? 'none' : 'block' }} src={ipfsLogo} alt='IPFS' title='Toggle navbar' />
+      </div>
+      <nav className='db pt4' role='menubar'>
+        <NavLink to='/' exact icon={StrokeMarketing} open={open}>{t('status:title')}</NavLink>
+        <NavLink to='/files/' icon={StrokeWeb} open={open}>{t('files:title')}</NavLink>
+        <NavLink to='/explore' icon={StrokeIpld} open={open}>{t('explore:tabName')}</NavLink>
+        <NavLink to='/peers' icon={StrokeCube} open={open}>{t('peers:title')}</NavLink>
+        <NavLink to='/settings' icon={StrokeSettings} disabled={!isSettingsEnabled} open={open}>{t('settings:title')}</NavLink>
+      </nav>
+      { open &&
+      <div className='mt5 flex flex-colum justify-center'>
+        <a className='link white f6 o-50 glow' href={codeUrl} target='_blank'>{t('status:codeLink')}</a>
+        <span className='mh2 white f6 o-50'>|</span>
+        <a className='link white f6 o-50 glow' href={bugsUrl} target='_blank'>{t('status:bugsLink')}</a>
+      </div> }
     </div>
-    <nav className='db pt4' role='menubar'>
-      <NavLink to='/' exact icon={StrokeMarketing} open={open}>{t('status:title')}</NavLink>
-      <NavLink to='/files/' icon={StrokeWeb} open={open}>{t('files:title')}</NavLink>
-      <NavLink to='/explore' icon={StrokeIpld} open={open}>{t('explore:tabName')}</NavLink>
-      <NavLink to='/peers' icon={StrokeCube} open={open}>{t('peers:title')}</NavLink>
-      <NavLink to='/settings' icon={StrokeSettings} disabled={!isSettingsEnabled} open={open}>{t('settings:title')}</NavLink>
-    </nav>
-  </div>
-)
+  )
+}
 
 export const NavBarContainer = ({ doToggleNavbar, configRaw, navbarIsOpen, navbarWidth, ...props }) => {
   const isSettingsEnabled = !!configRaw.data

--- a/src/status/NodeInfo.js
+++ b/src/status/NodeInfo.js
@@ -9,7 +9,7 @@ import { Title } from './Commons'
 import 'details-polyfill'
 
 const Block = ({ children }) => (
-  <div className='dt dt--fixed pt2'>
+  <div className='dt dt--fixed pt2 mw9'>
     { children }
   </div>
 )
@@ -90,7 +90,7 @@ class NodeInfo extends React.Component {
     return (
       <div className='f6'>
         <div className='flex flex-column flex-row-l flex-wrap-l justify-between-l'>
-          <div className='w-100 w-60-l pr2-l' >
+          <div className='w-100 w-60-l pr2-l flex-none' >
             <Title>{t('nodeInfo')}</Title>
             <Block>
               <Label>{t('peerId')}</Label>
@@ -118,9 +118,9 @@ class NodeInfo extends React.Component {
               <Value>{peers ? peers.length : 0}</Value>
             </Block>
           </div>
-          <div className='dn db-l w-100 w-40-l pl2-l'>
+          <div className='dn db-l w-100 w-40-l pl2-l flex-none'>
             <Title>{t('networkTraffic')}</Title>
-            <div className='flex-wrap flex-no-wrap-l flex justify-between'>
+            <div className='flex-wrap flex-no-wrap-l flex justify-between' style={{ maxWidth: 400 }}>
               <Graph
                 title={t('upSpeed')}
                 color='#69c4cd'

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -5,7 +5,6 @@ import CountryChart from './CountryChart'
 import NodeInfo from './NodeInfo'
 import NodeBandwidthChart from './NodeBandwidthChart'
 import Box from '../components/box/Box'
-import Footer from '../components/footer/Footer'
 
 export default translate('status')(({ t }) => (
   <div data-id='StatusPage'>
@@ -25,8 +24,5 @@ export default translate('status')(({ t }) => (
         </div>
       </div>
     </Box>
-    <div className='mt4'>
-      <Footer codeUrl='https://github.com/ipfs-shipyard/ipfs-webui' t={t} />
-    </div>
   </div>
 ))

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -5,24 +5,28 @@ import CountryChart from './CountryChart'
 import NodeInfo from './NodeInfo'
 import NodeBandwidthChart from './NodeBandwidthChart'
 import Box from '../components/box/Box'
+import Footer from '../components/footer/Footer'
 
 export default translate('status')(({ t }) => (
   <div data-id='StatusPage'>
     <Helmet>
       <title>{t('title')} - IPFS</title>
     </Helmet>
-    <Box className='pa3'>
+    <Box className='pa3' style={{ minHeight: 238 }}>
       <NodeInfo />
     </Box>
-    <Box className='mt3 pa3'>
+    <Box className='mt3 pa3' >
       <div className='flex flex-column flex-row-l'>
-        <div className='w-100 w-60-l pr0 pr2-l'>
+        <div className='w-100 w-60-l pr0 pr2-l flex-none'>
           <NodeBandwidthChart />
         </div>
-        <div className='w-100 w-40-l pl0 pl2-l'>
+        <div className='w-100 w-40-l pl0 pl2-l flex-none'>
           <CountryChart />
         </div>
       </div>
     </Box>
+    <div className='mt4'>
+      <Footer codeUrl='https://github.com/ipfs-shipyard/ipfs-webui' t={t} />
+    </div>
   </div>
 ))


### PR DESCRIPTION
Add a footer on the status page with links to the repo and bug reporing.

Only add it on the stats page as it looks weird during page load on the
other pages... it needs more design consideration before we roll it out
across all of them.

This isn't using our shared component library yet, but it can in the future.
There is a discussion to be had about whether components should decide
the namespace to use or if they should be agnostic to where the keys come
from, and let the page decide. The component library proposal suggested
we let the component decide, but it felt more natural to let the page decide
and wire it in. This would let us consolidate keys into fewer resources which
would be nice for translators (a couple of keys in lots and lots of resources
is awkward) and http requests (each namespace is loaded separately)

Also adds some layout tweaks on satatus page for large screens.

<img width="1552" alt="screenshot 2018-09-25 11 13 00" src="https://user-images.githubusercontent.com/58871/46008861-d8942080-c0b5-11e8-95f6-8c823afbacd9.png">


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>