### PR TITLE
fix: add quick-config script

### DIFF
--- a/quick-config.sh
+++ b/quick-config.sh
@@ -1,0 +1,4 @@
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://localhost:3000"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
+echo "Daemon has been configured for local WebUI!"


### PR DESCRIPTION
Adds the missing `quick-config.sh` script as noted in https://github.com/ipfs-shipyard/ipfs-webui#config-your-ipfs-daemon.