### PR TITLE
fix: add by path

### DIFF
--- a/src/files/file-input/ByPathModal.js
+++ b/src/files/file-input/ByPathModal.js
@@ -11,7 +11,7 @@ function ByPathModal ({ t, tReady, onCancel, onSubmit, className, ...props }) {
       p = `/ipfs/${p}`
     }
 
-    return isIPFS.ipfsPath(p.trim())
+    return isIPFS.ipfsPath(p)
   }
 
   return (

--- a/src/files/file-input/ByPathModal.js
+++ b/src/files/file-input/ByPathModal.js
@@ -6,9 +6,17 @@ import Icon from '../../icons/StrokeDecentralization'
 import TextInputModal from '../../components/text-input-modal/TextInputModal'
 
 function ByPathModal ({ t, tReady, onCancel, onSubmit, className, ...props }) {
+  const validatePath = (p) => {
+    if (!p.startsWith('/ipfs/')) {
+      p = `/ipfs/${p}`
+    }
+
+    return isIPFS.ipfsPath(p.trim())
+  }
+
   return (
     <TextInputModal
-      validate={(p) => isIPFS.ipfsPath(p.trim())}
+      validate={(p) => validatePath(p)}
       onSubmit={(p) => onSubmit(p.trim())}
       onChange={(p) => p.trimStart()}
       onCancel={onCancel}


### PR DESCRIPTION
Adds the ability to `add by path` with only the CID. Also works with `/ipfs/` prefixed.

![path](https://user-images.githubusercontent.com/33324750/46214459-28335000-c333-11e8-961c-93c6883984b5.gif)

Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/824.