### PR TITLE
fix: disable concurrent geoip lookups

### DIFF
--- a/src/bundles/index.js
+++ b/src/bundles/index.js
@@ -36,7 +36,7 @@ export default composeBundles(
   nodeBandwidthBundle,
   nodeBandwidthChartBundle(),
   peersBundle,
-  peerLocationsBundle(),
+  peerLocationsBundle({ concurrency: 1 }),
   notifyBundle,
   connectedBundle,
   retryInitBundle


### PR DESCRIPTION
This is a quick "fix" to slow down the rate at which we perform geoip lookups.

WIP on #848

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>