### PR TITLE
fix: detect api running on current origin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10276,13 +10276,13 @@
       }
     },
     "ipfs-redux-bundle": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-redux-bundle/-/ipfs-redux-bundle-4.1.0.tgz",
-      "integrity": "sha512-JT+SXG4GK68TIoat5G+6cNtxpAsqVqttBr0dbY8SBjmxbQ40EDDI58AgUC03UcPVPJ5FVJTHNqiw3X7osypdpA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ipfs-redux-bundle/-/ipfs-redux-bundle-4.1.1.tgz",
+      "integrity": "sha512-YysCN7ZY/mx4RsjE3L5M73gkmssBKlrORJyQ8yI5esDBRJvKoU/wrRdf9RQpST2mY4o8pfm4PFpQVVcPPm7kmg==",
       "requires": {
         "ipfs-api": "^25.0.0",
         "multiaddr": "^5.0.0",
-        "uri-to-multiaddr": "^1.0.0",
+        "uri-to-multiaddr": "^2.0.0",
         "window-or-global": "^1.0.1"
       }
     },
@@ -11595,7 +11595,7 @@
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
           "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
           "requires": {
             "xtend": "~4.0.0"
@@ -13869,7 +13869,7 @@
         },
         "peer-id": {
           "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
           "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
           "requires": {
             "async": "^2.6.0",
@@ -17156,7 +17156,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serialize-javascript": {
@@ -19312,9 +19312,9 @@
       }
     },
     "uri-to-multiaddr": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-1.0.0.tgz",
-      "integrity": "sha512-Ar9zkI69JJXaH401eRZnm57ECFoM1fFQ/SBepSYx4qADCmkf29zx2E0fLwrnHaFvbnLcZI10wHw1LRsYHgvuvQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-2.0.0.tgz",
+      "integrity": "sha512-hz0D0TMZn8UPdjWns3I3oz+r/KEIJYFxA8qa//Lk8YaQ0cUsPEsPPZNvEY08wbTP2yDBXrGzFdsYUpEzkjA8TQ==",
       "requires": {
         "ava": "^0.25.0",
         "is-ip": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "internal-nav-helper": "^1.0.2",
     "ipfs-css": "^0.10.0",
     "ipfs-geoip": "^2.3.0",
-    "ipfs-redux-bundle": "^4.1.0",
+    "ipfs-redux-bundle": "^4.1.1",
     "ipfs-unixfs": "^0.1.15",
     "ipld": "^0.17.3",
     "ipld-explorer-components": "^1.0.0",


### PR DESCRIPTION
- Allows detection of js-ipfs api when accessed from http://127.0.0.1:5002/webui
- Update ipfs-redux-bundle to v4.1.1

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>