### PR TITLE
feat: persist navbar state

### DIFF
--- a/src/bundles/index.js
+++ b/src/bundles/index.js
@@ -1,5 +1,4 @@
-import { composeBundles } from 'redux-bundler'
-
+import { composeBundles, createCacheBundle } from 'redux-bundler'
 import ipfsBundle from 'ipfs-redux-bundle'
 import { exploreBundle } from 'ipld-explorer-components'
 import appIdle from './app-idle'
@@ -18,8 +17,10 @@ import notifyBundle from './notify'
 import connectedBundle from './connected'
 import retryInitBundle from './retry-init'
 import identityBundle from './identity'
+import bundleCache from '../lib/bundle-cache'
 
 export default composeBundles(
+  createCacheBundle(bundleCache.set),
   appIdle({ idleTimeout: 5000 }),
   ipfsBundle({
     tryWindow: false
@@ -39,5 +40,5 @@ export default composeBundles(
   peerLocationsBundle({ concurrency: 1 }),
   notifyBundle,
   connectedBundle,
-  retryInitBundle
+  retryInitBundle,
 )

--- a/src/bundles/navbar.js
+++ b/src/bundles/navbar.js
@@ -1,6 +1,8 @@
 export default {
   name: 'navbar',
 
+  persistActions: ['NAVBAR_TOGGLE'],
+
   reducer: (state = { isOpen: true }, action) => {
     if (action.type === 'NAVBAR_TOGGLE') {
       return {

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,24 @@ import './index.css'
 import 'react-virtualized/styles.css'
 import App from './App'
 import getStore from './bundles'
+import bundleCache from './lib/bundle-cache'
 import { I18nextProvider } from 'react-i18next'
 import i18n from './i18n'
 
-ReactDOM.render(
-  <Provider store={getStore()}>
-    <I18nextProvider i18n={i18n} >
-      <App />
-    </I18nextProvider>
-  </Provider>, document.getElementById('root'))
+async function render () {
+  const initialData = await bundleCache.getAll()
+  if (initialData && process.env.NODE_ENV !== 'production') {
+    console.log('intialising store with data from cache', initialData)
+  }
+  const store = getStore(initialData)
+  ReactDOM.render(
+    <Provider store={store}>
+      <I18nextProvider i18n={i18n} >
+        <App />
+      </I18nextProvider>
+    </Provider>,
+    document.getElementById('root')
+  )
+}
+
+render()

--- a/src/lib/bundle-cache.js
+++ b/src/lib/bundle-cache.js
@@ -1,0 +1,9 @@
+import { getConfiguredCache } from 'money-clip'
+
+const bundleCache = getConfiguredCache({
+  name: 'bundle-cache',
+  version: 1,
+  maxAge: Infinity
+})
+
+export default bundleCache

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -57,7 +57,7 @@ export const NavBar = ({ t, isSettingsEnabled, width, open, onToggle }) => {
   return (
     <div className='h-100 fixed flex flex-column justify-between' style={{ width }}>
       <div className='flex flex-column'>
-        <div className='pointer' style={{ paddingTop: 35 }} onClick={onToggle}>
+        <div className='pointer navy' style={{ paddingTop: 35 }} onClick={onToggle}>
           <img className='center' style={{ height: 70, display: open ? 'block' : 'none' }} src={ipfsLogoText} alt='IPFS' title='Toggle navbar' />
           <img className='center' style={{ height: 70, display: open ? 'none' : 'block' }} src={ipfsLogo} alt='IPFS' title='Toggle navbar' />
         </div>


### PR DESCRIPTION
- If the user collapses the navbar, remember and init in the same state
next time.
- Adds the general purpose bundle caching support from redux-bundler.
- Init the store from the cache on first run
- Hide the alt text of the navbar logo to reduce loading jank.

![webui-navbar-persist](https://user-images.githubusercontent.com/58871/47861016-bd6dac80-dde9-11e8-8e34-4b5657e16c45.gif)


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>