### PR TITLE
fix: add missing quotes on Files screen

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -69,7 +69,7 @@
     "paragraph6": "<0>If you want to help push the Web UI forward, <1>check out its code</1> or <3>report a bug</3>!</0>"
   },
   "filesList": {
-    "noFiles": "<0>No files in this directory. Click the Add to IPFS button to add some.</0>"
+    "noFiles": "<0>No files in this directory. Click the “Add to IPFS” button to add some.</0>"
   },
   "addFilesInfo": "<0>Add files to your local IPFS node by clicking the <1>Add to IPFS</1> button above.</0>",
   "companionInfo": "<0>As you are using <1>IPFS Companion</1>, the files view is limited to files added while using the extension.</0>"


### PR DESCRIPTION
This PR fixes issue reported  by @Magik6k via https://www.transifex.com/ipfs/ipfs-webui/:

>  ![2018-11-17--19-08-27](https://user-images.githubusercontent.com/157609/48664257-30d71580-ea9c-11e8-9a17-6968d0188193.png)

Preview:

> ![2018-11-17--19-21-10](https://user-images.githubusercontent.com/157609/48664412-857b9000-ea9e-11e8-85ff-3348cbb6f0c7.png)

