### PR TITLE
docs: remove CORS Credentials header

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Run the **[cors-config.sh](./cors-config.sh)** script with:
 ```console
 > ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://localhost:3000", "https://webui.ipfs.io"]'
 > ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
 ```
 
 #### Reverting

--- a/cors-config.sh
+++ b/cors-config.sh
@@ -7,7 +7,6 @@ set -e
 
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[$ALLOW_ORIGINS]"
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
 
 echo "IPFS API CORS headers configured for $ALLOW_ORIGINS"
 echo "Please restart your IPFS daemon"

--- a/src/welcome/WelcomePage.js
+++ b/src/welcome/WelcomePage.js
@@ -70,7 +70,6 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
         <div className='bg-black-70 snow pa2 f7 nowrap overflow-x-scroll'>
           <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["{ window.location.origin }", "https://webui.ipfs.io"]'</code>
           <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'</code>
-          <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'</code>
         </div>
       </div> }
       <Trans i18nKey='notConnected.paragraph3'>


### PR DESCRIPTION
AFAIK Web UI does not need this, and we should not ask people to set it  if they don't really need it. 

See also:

- Potential problem with  `Access-Control-Allow-Credentials`: https://github.com/ipfs/go-ipfs/issues/5745
- HTTP Headers Cleanup: https://github.com/ipfs/in-web-browsers/issues/132
