### PR TITLE
feat: add ipfs-desktop support on ipfs-redux-bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "internal-nav-helper": "^1.0.2",
     "ipfs-css": "^0.10.0",
     "ipfs-geoip": "^2.3.0",
-    "ipfs-redux-bundle": "^4.1.1",
+    "ipfs-redux-bundle": "ipfs-shipyard/ipfs-redux-bundle#67262708962e035e302751031b926e840d6ca098",
     "ipfs-unixfs": "^0.1.15",
     "ipld": "^0.17.3",
     "ipld-explorer-components": "^1.0.0",

--- a/src/bundles/index.js
+++ b/src/bundles/index.js
@@ -23,9 +23,7 @@ import ipfsDesktop from './ipfs-desktop'
 export default composeBundles(
   createCacheBundle(bundleCache.set),
   appIdle({ idleTimeout: 5000 }),
-  ipfsBundle({
-    tryWindow: false
-  }),
+  ipfsBundle(),
   identityBundle,
   navbarBundle,
   routesBundle,

--- a/src/bundles/index.js
+++ b/src/bundles/index.js
@@ -23,7 +23,9 @@ import ipfsDesktop from './ipfs-desktop'
 export default composeBundles(
   createCacheBundle(bundleCache.set),
   appIdle({ idleTimeout: 5000 }),
-  ipfsBundle(),
+  ipfsBundle({
+    tryWindow: false
+  }),
   identityBundle,
   navbarBundle,
   routesBundle,


### PR DESCRIPTION
There is a typo on the branch name. Is not a `fix`, but a `feat`. Context: https://github.com/ipfs-shipyard/ipfs-desktop/pull/738.

## NEEDS

- [ ] https://github.com/ipfs-shipyard/ipfs-redux-bundle/pull/20 to be merged