### PR TITLE
Fix spacebar file select ff

### DIFF
--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -139,11 +139,11 @@ export class FilesList extends React.Component {
   }
 
   componentDidMount () {
-    document.addEventListener('keydown', this.keyHandler)
+    document.addEventListener('keyup', this.keyHandler)
   }
 
   componentWillUnmount () {
-    document.removeEventListener('keydown', this.keyHandler)
+    document.removeEventListener('keyup', this.keyHandler)
   }
 
   componentDidUpdate () {


### PR DESCRIPTION
Use the keyup rather than keydown. keydown has always been weird.

fixes #889


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>