### PR TITLE
fix: responsive peers map. larger country flags

### DIFF
--- a/src/peers/PeersTable/PeersTable.js
+++ b/src/peers/PeersTable/PeersTable.js
@@ -17,7 +17,7 @@ export class PeersTable extends React.Component {
     // Windows doesn't render the flags as emojis  ¯\_(ツ)_/¯
     const isWindows = window.navigator.appVersion.indexOf('Win') !== -1
     return (
-      <span className='pr2'>
+      <span className='pr2 f4'>
         {flagCode ? <CountryFlag code={flagCode} svg={isWindows} /> : '🏳️‍🌈'}
       </span>
     )
@@ -49,18 +49,18 @@ export class PeersTable extends React.Component {
         { peerLocationsForSwarm && <AutoSizer disableHeight>
           {({ width }) => (
             <Table
-              className='tl fw4 w-100 f7'
+              className='tl fw4 w-100 f6'
               headerClassName='aqua fw2 ttu tracked ph2'
               rowClassName={this.rowClassRenderer}
               width={width}
               height={tableHeight}
               headerHeight={32}
-              rowHeight={32}
+              rowHeight={36}
               rowCount={peerLocationsForSwarm.length}
               rowGetter={({ index }) => peerLocationsForSwarm[index]}>
-              <Column label={t('peerId')} dataKey='peerId' width={430} className='charcoal monospace pl2 truncate f7' />
-              <Column label={t('address')} cellRenderer={this.addressCellRenderer} dataKey='address' width={280} className='pl2' />
-              <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={220} className='pl2 f6 navy-muted b truncate' />
+              <Column label={t('peerId')} dataKey='peerId' width={405} className='charcoal monospace pl2 truncate f6' />
+              <Column label={t('address')} cellRenderer={this.addressCellRenderer} dataKey='address' width={290} className='pl2 f6' />
+              <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={400} className='pl2 f5 navy-muted fw5 truncate' />
             </Table>
           )}
         </AutoSizer> }

--- a/src/peers/PeersTable/PeersTable.js
+++ b/src/peers/PeersTable/PeersTable.js
@@ -58,9 +58,9 @@ export class PeersTable extends React.Component {
               rowHeight={36}
               rowCount={peerLocationsForSwarm.length}
               rowGetter={({ index }) => peerLocationsForSwarm[index]}>
-              <Column label={t('peerId')} dataKey='peerId' width={405} className='charcoal monospace pl2 truncate f6' />
-              <Column label={t('address')} cellRenderer={this.addressCellRenderer} dataKey='address' width={290} className='pl2 f6' />
-              <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={400} className='pl2 f5 navy-muted fw5 truncate' />
+              <Column label={t('peerId')} dataKey='peerId' width={380} className='charcoal monospace truncate f7 pl2' />
+              <Column label={t('address')} cellRenderer={this.addressCellRenderer} dataKey='address' width={300} className='f6 pl2' />
+              <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={400} className='f5 navy-muted fw5 truncate pl2' />
             </Table>
           )}
         </AutoSizer> }

--- a/src/peers/WorldMap/WorldMap.js
+++ b/src/peers/WorldMap/WorldMap.js
@@ -1,26 +1,45 @@
 import React from 'react'
 import ReactFauxDOM from 'react-faux-dom'
 import { connect } from 'redux-bundler-react'
-import { AutoSizer } from 'react-virtualized'
 import { translate } from 'react-i18next'
 import * as d3 from 'd3'
 import staticMapSrc from './StaticMap.svg'
 
 const WorldMap = ({ t }) => {
+  // Caluate a sensible size for the map
+  const { innerWidth } = window
+  // the d3 generated svg width includes a lot of ocean, that we crop for now, as it looks weird.
+  const svgWidthOversizeFactor = 1.7
+  // remove a constant amount for the chrome that surronds the map.
+  const sidebarAndPadding = 350
+  const availableWidth = innerWidth - sidebarAndPadding
+  let width = availableWidth * svgWidthOversizeFactor
+  // if the map gets too big the dots get lost in the dot grid, also it just overloads the viewers brain.
+  if (width > 4030) {
+    width = 4030
+  }
+  // if the map gets too small it becomes illegible. There will be some map cropping on mobile.
+  if (width < 700) {
+    width = 700
+  }
+  // the map has a native proportion, so account for that when we set the height.
+  let height = width * 0.273
   return (
-    <div className='flex w-100 mb4' style={{ 'height': '550px', background: `transparent url(${staticMapSrc}) center no-repeat` }}>
-      <AutoSizer disableHeight>
-        { ({ width }) => (
-          <GeoPath width={width} height={550}>
+    <div className='relative'>
+      <div className='mb4 overflow-hidden flex flex-column items-center'>
+        <div style={{ width, height, background: `transparent url(${staticMapSrc}) center no-repeat`, backgroundSize: 'auto 100%' }}>
+          <GeoPath width={width} height={height}>
             { ({ path }) => (
-              <MapPins height={550} width={width} path={path} />
+              <MapPins width={width} height={height} path={path} />
             )}
           </GeoPath>
-        )}
-      </AutoSizer>
-      <div className='flex flex-auto flex-column items-center self-end pb5'>
-        <div className='f1 fw5 aqua'><PeersCount /></div>
-        <div className='f4 b ttu'>{t('peers')}</div>
+        </div>
+      </div>
+      <div className='absolute bottom-0 left-0 right-0'>
+        <div className='flex flex-auto flex-column items-center self-end pb5-ns'>
+          <div className='f1 fw5 aqua'><PeersCount /></div>
+          <div className='f4 b ttu'>{t('peers')}</div>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
- Make make peer country names more legible. 
- Make peer map more responsive, within sensible bounds.

fixes #880 
fixes #903 

| 3840x2160 | 1440x900  | 411x731 pixel-2
|-------------|------------|------------------
| <img width="784" alt="screenshot 2018-12-13 at 12 42 02" src="https://user-images.githubusercontent.com/58871/49939703-750bd900-fed5-11e8-9a4b-458e0d0947d4.png"> | <img width="793" alt="screenshot 2018-12-13 at 12 43 08" src="https://user-images.githubusercontent.com/58871/49939739-9076e400-fed5-11e8-9540-2e287119515e.png"> | <img width="292" alt="screenshot 2018-12-13 at 12 43 45" src="https://user-images.githubusercontent.com/58871/49939783-abe1ef00-fed5-11e8-90ca-11d86fbf83d0.png">


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>