### PR TITLE
fix: add folder

### DIFF
--- a/public/locales/en/notify.json
+++ b/public/locales/en/notify.json
@@ -4,5 +4,6 @@
   "ipfsApiRequestFailed": "IPFS request failed. Please check if your daemon is running.",
   "windowIpfsRequestFailed": "IPFS request failed. Please check your IPFS Companion settings.",
   "ipfsIsBack": "Normal IPFS service has resumed. Enjoy!",
-  "filesEventFailed": "Failed to add files to IPFS. Please try again."
+  "filesEventFailed": "Failed to add files to IPFS. Please try again.",
+  "folderExists": "A folder with that name already exists. Please choose another."
 }

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -241,9 +241,9 @@ export default (opts = {}) => {
         progress: updateProgress
       })
 
-      if (res.length !== streams.length + 1) {
+      if (res.length !== streams.length + 2) {
         // See https://github.com/ipfs/js-ipfs-api/issues/797
-        throw new Error('Unable to finish upload: IPFS API returned a partial response. Try adding a smaller tree.')
+        throw Object.assign(new Error(`API returned a partial response.`), { code: 'ERR_API_RESPONSE' })
       }
 
       for (const { path, hash } of res) {
@@ -251,7 +251,12 @@ export default (opts = {}) => {
         if (path.indexOf('/') === -1 && path !== '') {
           const src = `/ipfs/${hash}`
           const dst = join(root, path)
-          await ipfs.files.cp([src, dst])
+
+          try {
+            await ipfs.files.cp([src, dst])
+          } catch (err) {
+            throw Object.assign(new Error(`Folder already exists.`), { code: 'ERR_FOLDER_EXISTS' })
+          }
         }
       }
 

--- a/src/bundles/notify.js
+++ b/src/bundles/notify.js
@@ -4,13 +4,14 @@ import { createSelector } from 'redux-bundler'
 # Notify
 - show error when ipfs goes away.
 - show ok when it comes back.
-- dismiss the the ok after 3s
+- dismiss the ok after 3s
 */
 
 const defaultState = {
   show: false,
   error: false,
-  eventId: null
+  eventId: null,
+  code: null
 }
 
 const notify = {
@@ -35,7 +36,8 @@ const notify = {
         ...state,
         show: true,
         error: true,
-        eventId: 'FILES_EVENT_FAILED'
+        eventId: 'FILES_EVENT_FAILED',
+        code: action.payload.error.code
       }
     }
 
@@ -57,14 +59,14 @@ const notify = {
     'selectNotify',
     'selectIpfsProvider',
     (notify, provider) => {
-      const { eventId } = notify
+      const { eventId, code } = notify
 
       if (eventId === 'STATS_FETCH_FAILED') {
         return provider === 'window.ipfs' ? 'windowIpfsRequestFailed' : 'ipfsApiRequestFailed'
       }
 
       if (eventId === 'FILES_EVENT_FAILED') {
-        return 'filesEventFailed'
+        return code === 'ERR_FOLDER_EXISTS' ? 'folderExists' : 'filesEventFailed'
       }
 
       if (eventId === 'STATS_FETCH_FINISHED') {


### PR DESCRIPTION
Adding a folder was failing because of the length of the api response. It would also fail and give an incoherent error if adding a folder with an existing folder name. 

![folder](https://user-images.githubusercontent.com/33324750/50699174-ff5fdc80-103e-11e9-8f1b-386bfde2bb4f.gif)

Fixes https://github.com/ipfs-shipyard/ipfs-webui/issues/922.