### PR TITLE
feat: add loading animation for files resp

### DIFF
--- a/src/components/loading-animation/LoadingAnimation.css
+++ b/src/components/loading-animation/LoadingAnimation.css
@@ -1,11 +1,12 @@
 
-.wrapper.loading {
+.LoadingAnimation {
+  position: relative;
   overflow: hidden;
   opacity: 0.4;
   background-color: #f0f6fa;
 }
 
-.loading::after {
+.LoadingAnimationSwipe::after {
   content: "";
   position: absolute;
   top: 0;
@@ -18,10 +19,10 @@
   white 70%,
     transparent 75%
   );
-  animation: progress 1.6s ease-in-out infinite;
+  animation: LoadingAnimationSwipe 1.6s ease-in-out infinite;
 }
 
-@keyframes progress {
+@keyframes LoadingAnimationSwipe {
   0% {
     transform: translate3d(-100%, 0, 0);
   }

--- a/src/components/loading-animation/LoadingAnimation.css
+++ b/src/components/loading-animation/LoadingAnimation.css
@@ -1,9 +1,5 @@
 
-.FilesList .wrapper {
-  position: relative;
-}
-
-.FilesList .wrapper.loading {
+.wrapper.loading {
   overflow: hidden;
   opacity: 0.4;
   background-color: #f0f6fa;

--- a/src/components/loading-animation/LoadingAnimation.js
+++ b/src/components/loading-animation/LoadingAnimation.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import classnames from 'classnames'
+import './LoadingAnimation.css'
+
+const LoadingAnimation = ({ loading, children }) => {
+  const wrapperAnimClass = classnames({ 'loading': loading }, ['wrapper'])
+
+  return (
+    <div className={wrapperAnimClass}>
+      { children }
+    </div>
+  )
+}
+
+export default LoadingAnimation

--- a/src/components/loading-animation/LoadingAnimation.js
+++ b/src/components/loading-animation/LoadingAnimation.js
@@ -1,13 +1,14 @@
 import React from 'react'
-import classnames from 'classnames'
 import './LoadingAnimation.css'
 
 const LoadingAnimation = ({ loading, children }) => {
-  const wrapperAnimClass = classnames({ 'loading': loading }, ['wrapper'])
+  if (!loading) return children
 
   return (
-    <div className={wrapperAnimClass}>
-      { children }
+    <div className='LoadingAnimation'>
+      <div className='LoadingAnimationSwipe'>
+        { children }
+      </div>
     </div>
   )
 }

--- a/src/files/files-list/FilesList.css
+++ b/src/files/files-list/FilesList.css
@@ -1,0 +1,36 @@
+
+.FilesList .wrapper {
+  position: relative;
+}
+
+.FilesList .wrapper.loading {
+  overflow: hidden;
+  opacity: 0.4;
+  background-color: #f0f6fa;
+}
+
+.loading::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 25%,
+  white 70%,
+    transparent 75%
+  );
+  animation: progress 1.6s ease-in-out infinite;
+}
+
+@keyframes progress {
+  0% {
+    transform: translate3d(-100%, 0, 0);
+  }
+
+  100% {
+    transform: translate3d(100%, 0, 0);
+  }
+}

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types'
 import { connect } from 'redux-bundler-react'
 import { Trans, translate } from 'react-i18next'
 import { join } from 'path'
-import classnames from 'classnames'
 import { sorts } from '../../bundles/files'
 // Reac DnD
 import { NativeTypes } from 'react-dnd-html5-backend'
@@ -14,8 +13,7 @@ import { DropTarget } from 'react-dnd'
 import Checkbox from '../../components/checkbox/Checkbox'
 import SelectedActions from '../selected-actions/SelectedActions'
 import File from '../file/File'
-// Styles
-import './FilesList.css'
+import LoadingAnimation from '../../components/loading-animation/LoadingAnimation';
 
 export class FilesList extends React.Component {
   static propTypes = {
@@ -288,9 +286,8 @@ export class FilesList extends React.Component {
     let { t, files, className, upperDir, connectDropTarget, isOver, canDrop, filesIsFetching } = this.props
     const { selected, isDragging } = this.state
     const allSelected = selected.length !== 0 && selected.length === files.length
-    const wrapperAnimClass = classnames({ 'loading': filesIsFetching }, ['wrapper'])
 
-    className = `FilesList no-select sans-serif border-box w-100 ${className}`
+    className = `FilesList no-select sans-serif border-box w-100 ${className} ${filesIsFetching && 'relative overflow-hidden'}`
 
     return connectDropTarget(
       <section ref={(el) => { this.root = el }} className={className} style={{ minHeight: '130px' }}>
@@ -310,7 +307,7 @@ export class FilesList extends React.Component {
           </div>
           <div className='pa2' style={{ width: '2.5rem' }} />
         </header>
-        <div className={wrapperAnimClass}>
+        <LoadingAnimation loading={filesIsFetching}>
           { upperDir &&
             <File
               ref={r => { this.filesRefs['..'] = r }}
@@ -327,7 +324,7 @@ export class FilesList extends React.Component {
               {...upperDir} />
           }
           {this.files}
-        </div>
+        </LoadingAnimation>
         {this.selectedMenu}
       </section>
     )

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -1,17 +1,21 @@
 /* global getComputedStyle */
-
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { connect } from 'redux-bundler-react'
 import PropTypes from 'prop-types'
+import { connect } from 'redux-bundler-react'
+import { Trans, translate } from 'react-i18next'
+import { join } from 'path'
+import classnames from 'classnames'
+import { sorts } from '../../bundles/files'
+// Reac DnD
+import { NativeTypes } from 'react-dnd-html5-backend'
+import { DropTarget } from 'react-dnd'
+// Components
 import Checkbox from '../../components/checkbox/Checkbox'
 import SelectedActions from '../selected-actions/SelectedActions'
 import File from '../file/File'
-import { NativeTypes } from 'react-dnd-html5-backend'
-import { DropTarget } from 'react-dnd'
-import { join } from 'path'
-import { sorts } from '../../bundles/files'
-import { Trans, translate } from 'react-i18next'
+// Styles
+import './FilesList.css'
 
 export class FilesList extends React.Component {
   static propTypes = {
@@ -281,9 +285,10 @@ export class FilesList extends React.Component {
   }
 
   render () {
-    let { t, files, className, upperDir, connectDropTarget, isOver, canDrop } = this.props
+    let { t, files, className, upperDir, connectDropTarget, isOver, canDrop, filesIsFetching } = this.props
     const { selected, isDragging } = this.state
     const allSelected = selected.length !== 0 && selected.length === files.length
+    const wrapperAnimClass = classnames({ 'loading': filesIsFetching }, ['wrapper'])
 
     className = `FilesList no-select sans-serif border-box w-100 ${className}`
 
@@ -305,22 +310,24 @@ export class FilesList extends React.Component {
           </div>
           <div className='pa2' style={{ width: '2.5rem' }} />
         </header>
-        { upperDir &&
-          <File
-            ref={r => { this.filesRefs['..'] = r }}
-            onNavigate={() => this.props.onNavigate(upperDir.path)}
-            onInspect={() => this.props.onInspect([upperDir])}
-            onAddFiles={this.props.onAddFiles}
-            onMove={this.move}
-            setIsDragging={this.isDragging}
-            translucent={isDragging || (isOver && canDrop)}
-            name='..'
-            focused={this.state.focused === '..'}
-            cantDrag
-            cantSelect
-            {...upperDir} />
-        }
-        {this.files}
+        <div className={wrapperAnimClass}>
+          { upperDir &&
+            <File
+              ref={r => { this.filesRefs['..'] = r }}
+              onNavigate={() => this.props.onNavigate(upperDir.path)}
+              onInspect={() => this.props.onInspect([upperDir])}
+              onAddFiles={this.props.onAddFiles}
+              onMove={this.move}
+              setIsDragging={this.isDragging}
+              translucent={isDragging || (isOver && canDrop)}
+              name='..'
+              focused={this.state.focused === '..'}
+              cantDrag
+              cantSelect
+              {...upperDir} />
+          }
+          {this.files}
+        </div>
         {this.selectedMenu}
       </section>
     )
@@ -349,5 +356,6 @@ export const FilesListWithDropTarget = DropTarget(NativeTypes.FILE, dropTarget, 
 
 export default connect(
   'selectNavbarWidth',
+  'selectFilesIsFetching',
   FilesListWithDropTarget
 )

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -13,7 +13,7 @@ import { DropTarget } from 'react-dnd'
 import Checkbox from '../../components/checkbox/Checkbox'
 import SelectedActions from '../selected-actions/SelectedActions'
 import File from '../file/File'
-import LoadingAnimation from '../../components/loading-animation/LoadingAnimation';
+import LoadingAnimation from '../../components/loading-animation/LoadingAnimation'
 
 export class FilesList extends React.Component {
   static propTypes = {

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -287,7 +287,7 @@ export class FilesList extends React.Component {
     const { selected, isDragging } = this.state
     const allSelected = selected.length !== 0 && selected.length === files.length
 
-    className = `FilesList no-select sans-serif border-box w-100 ${className} ${filesIsFetching && 'relative overflow-hidden'}`
+    className = `FilesList no-select sans-serif border-box w-100 ${className}`
 
     return connectDropTarget(
       <section ref={(el) => { this.root = el }} className={className} style={{ minHeight: '130px' }}>


### PR DESCRIPTION
Adds a loading animation when changing folders because some requests can hang for a bit and there was no clear indication that something was going on.

When you click on a folder, the files list gets an opacity and I went for something like the youtube cards animation, but keeping the content visible: 

![anim](https://user-images.githubusercontent.com/33324750/52134049-a0d84f00-263a-11e9-9698-f2bbabc69ba4.gif)

Fixes https://github.com/ipfs-shipyard/ipfs-webui/issues/926.