### PR TITLE
chore: update add dropdown

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -12,10 +12,10 @@
   "downloadPDF": "Download PDF.",
   "downloadInstead": "Try <1>downloading</1> it instead.",
   "cantBePreviewed": "Sorry, this file can't be previewed",
-  "addFile": "Add file",
-  "addFolder": "Add folder",
-  "addByPath": "Add by path",
-  "addToIPFS": "Add to IPFS",
+  "addFile": "File",
+  "addFolder": "Folder",
+  "addByPath": "From IPFS",
+  "addToIPFS": "Add",
   "newFolder": "New folder",
   "actions": {
     "add": "Add",
@@ -52,7 +52,7 @@
     "descriptionFile": "{count, plural, one {Are you sure you want to delete this file? This action is permanent and cannot be reversed.} other {Are you sure you want to delete {count} files? This action is permanent and cannot be reversed.}}"
   },
   "addByPathModal": {
-    "title": "Add by path",
+    "title": "Add from IPFS",
     "description": "Insert the path to add."
   },
   "newFolderModal": {

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -5,7 +5,6 @@ import { connect } from 'redux-bundler-react'
 import downloadFile from './download-file'
 import { join } from 'path'
 import { translate, Trans } from 'react-i18next'
-
 // Components
 import Breadcrumbs from './breadcrumbs/Breadcrumbs'
 import FilesList from './files-list/FilesList'
@@ -13,15 +12,21 @@ import FilePreview from './file-preview/FilePreview'
 import FileInput from './file-input/FileInput'
 import ContextMenu from './context-menu/ContextMenu'
 import Overlay from '../components/overlay/Overlay'
+import NewFolderModal from './new-folder-modal/NewFolderModal'
 import ShareModal from './share-modal/ShareModal'
 import RenameModal from './rename-modal/RenameModal'
 import DeleteModal from './delete-modal/DeleteModal'
 import AboutIpfs from '../components/about-ipfs/AboutIpfs'
 import Box from '../components/box/Box'
+// Icons
+import FolderIcon from '../icons/StrokeFolder'
 
 const defaultState = {
   downloadAbort: null,
   downloadProgress: null,
+  newFolder: {
+    isOpen: false
+  },
   share: {
     isOpen: false,
     link: ''
@@ -65,7 +70,10 @@ class FilesPage extends React.Component {
 
   resetState = (field) => this.setState({ [field]: defaultState[field] })
 
-  makeDir = (path) => this.props.doFilesMakeDir(join(this.props.files.path, path))
+  makeDir = (path) => {
+    this.resetState('newFolder')
+    this.props.doFilesMakeDir(join(this.props.files.path, path))
+  }
 
   componentDidMount () {
     this.props.doFilesFetch()
@@ -117,6 +125,14 @@ class FilesPage extends React.Component {
     }
 
     doUpdateHash(`/explore/ipfs/${hash}`)
+  }
+
+  showNewFolderModal = () => {
+    this.setState({
+      newFolder: {
+        isOpen: true
+      }
+    })
   }
 
   showShareModal = (files) => {
@@ -196,7 +212,7 @@ class FilesPage extends React.Component {
       doFilesMove, doFilesNavigateTo, doFilesUpdateSorting
     } = this.props
 
-    const { share, rename, delete: deleteModal } = this.state
+    const { newFolder, share, rename, delete: deleteModal } = this.state
 
     const isCompanion = ipfsProvider === 'window.ipfs'
     const filesExist = files && files.content && files.content.length
@@ -214,12 +230,17 @@ class FilesPage extends React.Component {
               <Breadcrumbs path={files.path} onClick={doFilesNavigateTo} />
 
               { files.type === 'directory'
-                ? <FileInput
-                  className='ml-auto'
-                  onMakeDir={this.makeDir}
-                  onAddFiles={this.add}
-                  onAddByPath={this.addByPath}
-                  addProgress={writeFilesProgress} />
+                ? <div className='ml-auto flex items-center'>
+                  <span
+                    className='mr3 flex items-center f6 gray pointer'
+                    onClick={() => this.showNewFolderModal()}>
+                    <FolderIcon className='mr1 fill-gray w2 o-80 glow' />{t('newFolder')}
+                  </span>
+                  <FileInput
+                    onAddFiles={this.add}
+                    onAddByPath={this.addByPath}
+                    addProgress={writeFilesProgress} />
+                </div>
                 : <div className='ml-auto' style={{ width: '1.5rem' }}> {/* to render correctly in Firefox */}
                   <ContextMenu
                     handleClick={this.handleContextMenuClick}
@@ -259,6 +280,13 @@ class FilesPage extends React.Component {
               : <FilePreview {...files} gatewayUrl={this.props.gatewayUrl} /> }
           </div>
         }
+
+        <Overlay show={newFolder.isOpen} onLeave={() => this.resetState('newFolder')}>
+          <NewFolderModal
+            className='outline-0'
+            onCancel={() => this.resetState('newFolder')}
+            onSubmit={this.makeDir} />
+        </Overlay>
 
         <Overlay show={share.isOpen} onLeave={() => this.resetState('share')}>
           <ShareModal

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -18,6 +18,7 @@ import RenameModal from './rename-modal/RenameModal'
 import DeleteModal from './delete-modal/DeleteModal'
 import AboutIpfs from '../components/about-ipfs/AboutIpfs'
 import Box from '../components/box/Box'
+import Button from '../components/button/Button'
 // Icons
 import FolderIcon from '../icons/StrokeFolder'
 
@@ -231,11 +232,13 @@ class FilesPage extends React.Component {
 
               { files.type === 'directory'
                 ? <div className='ml-auto flex items-center'>
-                  <span
-                    className='mr3 flex items-center f6 gray pointer'
+                  <Button
+                    className='mr1 flex items-center f6 fw3 pointer'
+                    color='charcoal-muted'
+                    bg='bg-transparent'
                     onClick={() => this.showNewFolderModal()}>
-                    <FolderIcon className='mr1 fill-gray w2 o-80 glow' />{t('newFolder')}
-                  </span>
+                    <FolderIcon viewBox='10 15 80 80' height='20px' className='fill-charcoal-muted w2' />{t('newFolder')}
+                  </Button>
                   <FileInput
                     onAddFiles={this.add}
                     onAddByPath={this.addByPath}

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -233,11 +233,12 @@ class FilesPage extends React.Component {
               { files.type === 'directory'
                 ? <div className='ml-auto flex items-center'>
                   <Button
-                    className='mr1 flex items-center f6 fw3 pointer'
+                    className='mr3 f6 pointer'
                     color='charcoal-muted'
                     bg='bg-transparent'
                     onClick={() => this.showNewFolderModal()}>
-                    <FolderIcon viewBox='10 15 80 80' height='20px' className='fill-charcoal-muted w2' />{t('newFolder')}
+                    <FolderIcon viewBox='10 15 80 80' height='20px' className='fill-charcoal-muted w2 v-mid' />
+                    <span className='fw3'>{t('newFolder')}</span>
                   </Button>
                   <FileInput
                     onAddFiles={this.add}

--- a/src/files/file-input/FileInput.js
+++ b/src/files/file-input/FileInput.js
@@ -12,7 +12,7 @@ import Button from '../../components/button/Button'
 import Overlay from '../../components/overlay/Overlay'
 import ByPathModal from './ByPathModal'
 
-const AddButton = translate('files')(({ progress = null, t, tReady, ...props }) => {
+const AddButton = translate('files')(({ progress = null, t, tReady, i18n, lng, ...props }) => {
   const sending = progress !== null
   const cls = classnames({
     'bg-grey light-grey': sending,

--- a/src/files/file-input/FileInput.js
+++ b/src/files/file-input/FileInput.js
@@ -8,6 +8,7 @@ import FolderIcon from '../../icons/StrokeFolder'
 import DecentralizationIcon from '../../icons/StrokeDecentralization'
 // Components
 import { Dropdown, DropdownMenu, Option } from '../dropdown/Dropdown'
+import Button from '../../components/button/Button'
 import Overlay from '../../components/overlay/Overlay'
 import ByPathModal from './ByPathModal'
 
@@ -16,17 +17,17 @@ const AddButton = translate('files')(({ progress = null, t, tReady, ...props }) 
   const cls = classnames({
     'bg-grey light-grey': sending,
     'pointer bg-green white': !sending
-  }, ['Button f6 relative transition-all sans-serif dib v-mid fw5 nowrap lh-copy bn br1 pa2 focus-outline'])
+  }, ['f6 relative'])
 
   return (
-    <button disabled={sending} className={cls} style={{ width: '120px' }} {...props}>
+    <Button disabled={sending} className={cls} minWidth='120px' {...props}>
       <div className='absolute top-0 left-0 1 pa2 w-100 z-2'>
         { sending ? `${progress.toFixed(0)}%` : `+ ${t('addToIPFS')}` }
       </div>&nbsp;
 
       { sending &&
         <div className='transition-all absolute top-0 br1 left-0 h-100 z-1' style={{ width: `${progress}%`, background: 'rgba(0,0,0,0.1)' }} /> }
-    </button>
+    </Button>
   )
 })
 

--- a/src/files/file-input/FileInput.js
+++ b/src/files/file-input/FileInput.js
@@ -10,7 +10,6 @@ import DecentralizationIcon from '../../icons/StrokeDecentralization'
 import { Dropdown, DropdownMenu, Option } from '../dropdown/Dropdown'
 import Overlay from '../../components/overlay/Overlay'
 import ByPathModal from './ByPathModal'
-import NewFolderModal from './NewFolderModal'
 
 const AddButton = translate('files')(({ progress = null, t, tReady, ...props }) => {
   const sending = progress !== null
@@ -20,7 +19,7 @@ const AddButton = translate('files')(({ progress = null, t, tReady, ...props }) 
   }, ['Button f6 relative transition-all sans-serif dib v-mid fw5 nowrap lh-copy bn br1 pa2 focus-outline'])
 
   return (
-    <button disabled={sending} className={cls} style={{ width: '144px' }} {...props}>
+    <button disabled={sending} className={cls} style={{ width: '120px' }} {...props}>
       <div className='absolute top-0 left-0 1 pa2 w-100 z-2'>
         { sending ? `${progress.toFixed(0)}%` : `+ ${t('addToIPFS')}` }
       </div>&nbsp;
@@ -33,7 +32,6 @@ const AddButton = translate('files')(({ progress = null, t, tReady, ...props }) 
 
 class FileInput extends React.Component {
   static propTypes = {
-    onMakeDir: PropTypes.func.isRequired,
     onAddFiles: PropTypes.func.isRequired,
     onAddByPath: PropTypes.func.isRequired,
     addProgress: PropTypes.number,
@@ -44,7 +42,6 @@ class FileInput extends React.Component {
   state = {
     dropdown: false,
     byPathModal: false,
-    newFolderModal: false,
     force100: false
   }
 
@@ -83,11 +80,6 @@ class FileInput extends React.Component {
     this.toggleModal('byPath')()
   }
 
-  onMakeDir = (path) => {
-    this.props.onMakeDir(path)
-    this.toggleModal('newFolder')()
-  }
-
   render () {
     let { progress, t } = this.props
     if (this.state.force100) {
@@ -114,10 +106,6 @@ class FileInput extends React.Component {
               <DecentralizationIcon className='fill-aqua w2 mr1' />
               {t('addByPath')}
             </Option>
-            <Option className='bt border-snow' onClick={this.toggleModal('newFolder')}>
-              <FolderIcon className='fill-aqua w2 mr1' />
-              {t('newFolder')}
-            </Option>
           </DropdownMenu>
         </Dropdown>
 
@@ -141,13 +129,6 @@ class FileInput extends React.Component {
             className='outline-0'
             onCancel={this.toggleModal('byPath')}
             onSubmit={this.onAddByPath} />
-        </Overlay>
-
-        <Overlay show={this.state.newFolderModal} onLeave={this.toggleModal('newFolder')}>
-          <NewFolderModal
-            className='outline-0'
-            onCancel={this.toggleModal('newFolder')}
-            onSubmit={this.onMakeDir} />
         </Overlay>
       </div>
     )

--- a/src/files/new-folder-modal/NewFolderModal.js
+++ b/src/files/new-folder-modal/NewFolderModal.js
@@ -15,8 +15,7 @@ function NewFolderModal ({ t, tReady, onCancel, onSubmit, className, ...props })
       description={t('newFolderModal.description')}
       icon={FolderIcon}
       submitText={t('actions.create')}
-      {...props}
-    />
+      {...props} />
   )
 }
 

--- a/src/files/rename-modal/RenameModal.js
+++ b/src/files/rename-modal/RenameModal.js
@@ -18,8 +18,7 @@ function RenameModal ({ t, tReady, onCancel, onSubmit, filename, folder, classNa
       description={t(`renameModal.description${context}`)}
       icon={PencilIcon}
       submitText={t('actions.save')}
-      {...props}
-    />
+      {...props} />
   )
 }
 


### PR DESCRIPTION
As per https://github.com/ipfs-shipyard/ipfs-webui/issues/915#issuecomment-452768683, I've refactored the add dropdown. Heavily inspired by Drive and Dropbox.

- Separate the `create new folder` from the `add to ipfs` dropdown. This way, everything inside that dropdow is to add file/folder/cid to our repo.
- Renamed the dropdown to just `+ Add`. Previously we had `+ Add to IPFS`, which is not 100% correct. This let me update the `Add by path` which was super confusing, to `Add from IPFS`, which I think is more clear because it tells you you're adding something that is already on IPFS. 

<img width="1279" alt="1" src="https://user-images.githubusercontent.com/33324750/52208434-8be8ff00-2878-11e9-8663-781844a5b1ee.png">

<img width="1279" alt="2" src="https://user-images.githubusercontent.com/33324750/52208435-8d1a2c00-2878-11e9-9732-a42d4fccbf16.png">

Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/915.