### PR TITLE
chore: add example to addFromIpfs modal

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -53,7 +53,8 @@
   },
   "addByPathModal": {
     "title": "Add from IPFS",
-    "description": "Insert the path to add."
+    "description": "Insert an IPFS path (CID) to add.",
+    "examples": "Examples:"
   },
   "newFolderModal": {
     "title": "New folder",

--- a/src/components/text-input-modal/TextInputModal.js
+++ b/src/components/text-input-modal/TextInputModal.js
@@ -10,7 +10,7 @@ class TextInputModal extends React.Component {
     onChange: PropTypes.func,
     title: PropTypes.string.isRequired,
     icon: PropTypes.func.isRequired,
-    description: PropTypes.string,
+    description: PropTypes.node,
     submitText: PropTypes.string,
     validate: PropTypes.func,
     defaultValue: PropTypes.string,
@@ -98,7 +98,9 @@ class TextInputModal extends React.Component {
     return (
       <Modal {...props} className={className} onCancel={onCancel}>
         <ModalBody title={title} icon={icon}>
-          { description &&
+          { description && typeof description === 'object' && description }
+
+          { description && typeof description === 'string' &&
             <p className='gray w-80 center'>{description}</p>
           }
 

--- a/src/files/file-input/ByPathModal.js
+++ b/src/files/file-input/ByPathModal.js
@@ -14,6 +14,19 @@ function ByPathModal ({ t, tReady, onCancel, onSubmit, className, ...props }) {
     return isIPFS.ipfsPath(p)
   }
 
+  const getDescription = () => {
+    const codeClass = 'w-90 mb1 pa1 bg-snow f7 charcoal-muted truncate'
+
+    return (
+      <div className='mb3 flex flex-column items-center'>
+        <p className='gray w-80'>{t('addByPathModal.description')}</p>
+        <span className='w-80 mv2 f7 charcoal-muted'>{t('addByPathModal.examples')}</span>
+        <code className={codeClass}>/ipfs/QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V</code>
+        <code className={codeClass}>QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB</code>
+      </div>
+    )
+  }
+
   return (
     <TextInputModal
       validate={(p) => validatePath(p)}
@@ -22,7 +35,7 @@ function ByPathModal ({ t, tReady, onCancel, onSubmit, className, ...props }) {
       onCancel={onCancel}
       className={className}
       title={t('addByPathModal.title')}
-      description={t('addByPathModal.description')}
+      description={getDescription()}
       icon={Icon}
       submitText={t('actions.add')}
       {...props}


### PR DESCRIPTION
Clarifies what `Add From IPFS` modal does:

<img width="496" alt="from-ipfs" src="https://user-images.githubusercontent.com/33324750/52477440-c95fcc00-2b99-11e9-85a9-5d9ed748f923.png">