### PR TITLE
chore: extract ContextMenu from each file

### DIFF
--- a/src/files/context-menu/ContextMenu.js
+++ b/src/files/context-menu/ContextMenu.js
@@ -2,9 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
-import GlyphDots from '../../icons/GlyphDots'
 import { Dropdown, DropdownMenu, Option } from '../dropdown/Dropdown'
-
+import GlyphDots from '../../icons/GlyphDots'
 import StrokeCopy from '../../icons/StrokeCopy'
 import StrokeShare from '../../icons/StrokeShare'
 import StrokePencil from '../../icons/StrokePencil'
@@ -19,12 +18,13 @@ class ContextMenu extends React.Component {
     translateX: PropTypes.number,
     translateY: PropTypes.number,
     left: PropTypes.number,
+    showDots: PropTypes.bool,
     onDelete: PropTypes.func,
     onRename: PropTypes.func,
     onDownload: PropTypes.func,
     onInspect: PropTypes.func,
     onShare: PropTypes.func,
-    hash: PropTypes.string.isRequired,
+    hash: PropTypes.string,
     className: PropTypes.string,
     t: PropTypes.func.isRequired,
     tReady: PropTypes.bool.isRequired
@@ -37,6 +37,7 @@ class ContextMenu extends React.Component {
     right: 'auto',
     translateX: 0,
     translateY: 0,
+    showDots: true,
     className: ''
   }
 
@@ -50,11 +51,11 @@ class ContextMenu extends React.Component {
   }
 
   render () {
-    const { t, onRename, onDelete, onDownload, onInspect, onShare, translateX, translateY, className } = this.props
+    const { t, onRename, onDelete, onDownload, onInspect, onShare, translateX, translateY, className, showDots } = this.props
 
     return (
       <Dropdown className={className}>
-        <GlyphDots width='1.5rem' className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.props.handleClick} />
+        { showDots && <GlyphDots width='1.5rem' className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.props.handleClick} /> }
         <DropdownMenu
           top={-8}
           arrowMarginRight='11px'

--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { findDOMNode } from 'react-dom'
 import PropTypes from 'prop-types'
 import { join, basename } from 'path'
 import filesize from 'filesize'
@@ -7,17 +6,12 @@ import filesize from 'filesize'
 import { DropTarget, DragSource } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 // Components
+import GlyphDots from '../../icons/GlyphDots'
 import Tooltip from '../../components/tooltip/Tooltip'
 import Checkbox from '../../components/checkbox/Checkbox'
 import FileIcon from '../file-icon/FileIcon'
-import ContextMenu from '../context-menu/ContextMenu'
 
 class File extends React.Component {
-  constructor (props) {
-    super(props)
-    this.contextMenuRef = React.createRef()
-  }
-
   static propTypes = {
     name: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
@@ -31,13 +25,9 @@ class File extends React.Component {
     onNavigate: PropTypes.func.isRequired,
     onAddFiles: PropTypes.func.isRequired,
     onMove: PropTypes.func.isRequired,
-    onShare: PropTypes.func,
-    onDelete: PropTypes.func,
-    onRename: PropTypes.func,
-    onInspect: PropTypes.func,
-    onDownload: PropTypes.func,
     coloured: PropTypes.bool,
     translucent: PropTypes.bool,
+    handleContextMenuClick: PropTypes.func,
     // Injected by DragSource and DropTarget
     isOver: PropTypes.bool.isRequired,
     canDrop: PropTypes.bool.isRequired,
@@ -51,47 +41,20 @@ class File extends React.Component {
     translucent: false
   }
 
-  state = {
-    isContextMenuOpen: false,
-    translateX: 0,
-    translateY: 0
+  handleCtxLeftClick = (ev) => {
+    const { name, type, size, hash, path } = this.props
+    const dotsPosition = this.dotsWrapper.getBoundingClientRect()
+    this.props.handleContextMenuClick(ev, 'LEFT', { name, size, type, hash, path }, dotsPosition)
   }
 
-  handleCtxLeftClick = (ev) => this.handleContextMenuClick(ev, 'LEFT')
-
-  handleCtxRightClick = (ev) => this.handleContextMenuClick(ev, 'RIGHT')
-
-  handleContextMenuClick = (ev, clickType) => {
-    // This is needed to disable the native OS right-click menu
-    // and deal with the clicking on the ContextMenu options
-    if (ev !== undefined && typeof ev !== 'string') {
-      ev.preventDefault()
-    }
-
-    if (clickType === 'RIGHT') {
-      ev.persist()
-
-      const ctxMenu = findDOMNode(this.contextMenuRef.current)
-      const ctxMenuPosition = ctxMenu.getBoundingClientRect()
-
-      this.setState(state => ({
-        isContextMenuOpen: !state.isContextMenuOpen,
-        translateX: (ctxMenuPosition.x + ctxMenuPosition.width / 2) - ev.clientX,
-        translateY: (ctxMenuPosition.y + ctxMenuPosition.height / 2) - ev.clientY
-      }))
-    } else {
-      this.setState(state => ({
-        isContextMenuOpen: !state.isContextMenuOpen,
-        translateX: 0,
-        translateY: 0
-      }))
-    }
+  handleCtxRightClick = (ev) => {
+    const { name, type, size, hash, path } = this.props
+    this.props.handleContextMenuClick(ev, 'RIGHT', { name, size, type, hash, path })
   }
 
   render () {
     let {
-      selected, focused, translucent, coloured, hash, name, type, size, cumulativeSize,
-      onSelect, onNavigate, onDelete, onInspect, onRename, onShare, onDownload,
+      selected, focused, translucent, coloured, hash, name, type, size, cumulativeSize, onSelect, onNavigate,
       isOver, canDrop, cantDrag, cantSelect, connectDropTarget, connectDragPreview, connectDragSource,
       styles = {}
     } = this.props
@@ -142,19 +105,8 @@ class File extends React.Component {
         <div className='size pl2 pr4 pv1 flex-none f6 dn db-l tr charcoal-muted'>
           {size}
         </div>
-        <div className='ph2 pv1 relative' style={{ width: '2.5rem' }}>
-          <ContextMenu
-            ref={this.contextMenuRef}
-            handleClick={this.handleCtxLeftClick}
-            translateX={this.state.translateX}
-            translateY={this.state.translateY}
-            isOpen={this.state.isContextMenuOpen}
-            onShare={onShare}
-            onDelete={onDelete}
-            onRename={onRename}
-            onInspect={onInspect}
-            onDownload={onDownload}
-            hash={hash} />
+        <div ref={el => { this.dotsWrapper = el }}>
+          <GlyphDots width='1.5rem' className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.handleCtxLeftClick} />
         </div>
       </div>
     )


### PR DESCRIPTION
Until this point every `<File>` component had a `<ContextMenu>` component inside. I've extracted the ContextMenu out, so now a `<File>` only has placeholder dots and calls one `<ContextMenu>` that is shared by all files and can be found on the `<FilesList>`. This should help the performance of the app as it cuts a huge amount of DOM nodes.