### PR TITLE
fix: firefox svg render

### DIFF
--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -105,8 +105,8 @@ class File extends React.Component {
         <div className='size pl2 pr4 pv1 flex-none f6 dn db-l tr charcoal-muted'>
           {size}
         </div>
-        <div ref={el => { this.dotsWrapper = el }}>
-          <GlyphDots width='1.5rem' className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.handleCtxLeftClick} />
+        <div ref={el => { this.dotsWrapper = el }} className='ph2' style={{ width: '2.5rem' }}>
+          <GlyphDots className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.handleCtxLeftClick} />
         </div>
       </div>
     )

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -340,7 +340,7 @@ export class FilesList extends React.Component {
         contextMenu: {
           ...state.contextMenu,
           isOpen: !state.contextMenu.isOpen,
-          translateX: (ctxMenuPosition.x + ctxMenuPosition.width / 2) - (dotsPosition && dotsPosition.x) - 11,
+          translateX: (ctxMenuPosition.x + ctxMenuPosition.width / 2) - (dotsPosition && dotsPosition.x) - 19,
           translateY: (ctxMenuPosition.y + ctxMenuPosition.height / 2) - (dotsPosition && dotsPosition.y) - 30,
           currentFile: file
         }


### PR DESCRIPTION
After the `<ContextMenu>` refactor in https://github.com/ipfs-shipyard/ipfs-webui/pull/956 some known SVG rendering issues in Firefox reappeared. This PR fixes that.