### PR TITLE
Add notice for contributors about Transifex process

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,58 +157,11 @@ To inspect the built bundle for bundled modules and their size, first `build` th
 
 ## Translations
 
-The translations are stored on [./public/locales](./public/locales) and the English version is the source of truth.
+The translations are stored on [./public/locales](./public/locales) and the English version is the source of truth. We use Transifex to help us translate WebUI to another languages.
 
-We use Transifex to help us translate WebUI to another languages. If you're interested in contributing, go to [our page on Transifex](https://www.transifex.com/ipfs/ipfs-webui/translate/), create an account, pick a language and start translating.
+**If you're interested in contributing a translation**, go to [our page on Transifex](https://www.transifex.com/ipfs/ipfs-webui/translate/), create an account, pick a language and start translating.
 
-### To Sync Translations
-
-1. Install and set up [command-line client (`tx`)](https://docs.transifex.com/client/installing-the-client)
-2. To download new translations from Transifex: `tx pull -a`
-    - this should create/update files in `public/locales/*` that need to be committed
-    - if a new language is created, remember to add it to `src/i18n.js`
-3. If there are new locales, run [`lol`](https://github.com/olizilla/lol) to update our [`languages.json`](src/lib/languages.json)
-
-```console
-npx -q @olizilla/lol public/locales > src/lib/languages.json
-```
-
-### Namespaces and source files
-
-We've split up our files by tab, so you can find the translations files at
-
-- **Files** `->` `public/locales/en/files.json`
-- **Explore** `->` `public/locales/en/explore.json`
-
-..etc. The filename is the **namespace** that `i18next` will look up to find the keys for the right section.
-
-We define our **source file** to be the `en` locale, in `public/locales/en/*`. Developers should update those files directly. Changes to from master branch are fetched by Transifex automatically every day for our lovely team of translators to ruminate on.
-
-All other locales are `pull`ed from Transifex service via the `tx` commandline tool.
-
-### Adding or updating keys
-
-If you want to add new keys or change existing values in the `en` locale, you should make sure you have the latest from transifex first.
-
-For example, before adding keys to `public/locales/en/explore.json`, first check you've got the latest source file:
-
-```console
-$ tx pull -r ipld-explorer.explore-json -s
-tx INFO: Pulling translations for resource ipld-explorer.explore-json (source: public/locales/en/explore.json)
-tx WARNING:  -> ko_KR: public/locales/ko_KR/explore.json
-tx WARNING:  -> en: public/locales/en/explore.json
-...
-```
-
-- `-s` means "include the source file when pulling", which in our case is the `en` versions.
-- `-r ipld-explorer.explore-json` means just `explore.json` file. The mappings of resource name to files
-is in the `.tx/config` file.
-
-Now make your changes and add great keys and snappy `en` default values for them. When you are done, commit your changes as per usual. Changes to from master branch are fetched by Transifex automatically.
-
-For **more info on our i18n process** at IPFS, check out:
-
-- https://github.com/ipfs/i18n
+You can read more on how we use Transifex and i18next in this app at [`docs/LOCALIZATION.md`](docs/LOCALIZATION.md)
 
 ## Releasing a new version of the WebUI.
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -1,7 +1,11 @@
+# Translating the IPFS Web UI
 
+Welcome to the Web UI branch of the [IPFS Translation Project  🌐✍️🖖](https://github.com/ipfs/i18n)
 
+We use [transifex.com](https://www.transifex.com/ipfs/public/) to manage translations. **Please don't edit the locale files directly.**
 
 For more info on our i18n process at IPFS, check out: https://github.com/ipfs/i18n
+
 
 ## Pulling translations from Transifex
 
@@ -15,6 +19,7 @@ For more info on our i18n process at IPFS, check out: https://github.com/ipfs/i1
 npx -q @olizilla/lol public/locales > src/lib/languages.json
 ```
 
+
 ## Namespaces and source files
 
 We've split up our files by tab, so you can find the translations files at
@@ -27,6 +32,7 @@ We've split up our files by tab, so you can find the translations files at
 We define our **source file** to be the `en` locale, in `public/locales/en/*`. Developers should update those files directly. Changes to from master branch are fetched by Transifex automatically every day for our lovely team of translators to ruminate on.
 
 All other locales are `pull`ed from Transifex service via the `tx` commandline tool.
+
 
 ### Adding or updating keys
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -1,0 +1,49 @@
+
+
+
+For more info on our i18n process at IPFS, check out: https://github.com/ipfs/i18n
+
+## Pulling translations from Transifex
+
+1. Install and set up [command-line client (`tx`)](https://docs.transifex.com/client/installing-the-client)
+2. To download new translations from Transifex: `tx pull -a`
+    - this should create/update files in `public/locales/*` that need to be committed
+    - if a new language is created, remember to add it to `src/i18n.js`
+3. If there are new locales, run [`lol`](https://github.com/olizilla/lol) to update our [`languages.json`](src/lib/languages.json)
+
+```console
+npx -q @olizilla/lol public/locales > src/lib/languages.json
+```
+
+## Namespaces and source files
+
+We've split up our files by tab, so you can find the translations files at
+
+- **Files** `->` `public/locales/en/files.json`
+- **Explore** `->` `public/locales/en/explore.json`
+
+..etc. The filename is the **namespace** that `i18next` will look up to find the keys for the right section.
+
+We define our **source file** to be the `en` locale, in `public/locales/en/*`. Developers should update those files directly. Changes to from master branch are fetched by Transifex automatically every day for our lovely team of translators to ruminate on.
+
+All other locales are `pull`ed from Transifex service via the `tx` commandline tool.
+
+### Adding or updating keys
+
+If you want to add new keys or change existing values in the `en` locale, you should make sure you have the latest from transifex first.
+
+For example, before adding keys to `public/locales/en/explore.json`, first check you've got the latest source file:
+
+```console
+$ tx pull -r ipld-explorer.explore-json -s
+tx INFO: Pulling translations for resource ipld-explorer.explore-json (source: public/locales/en/explore.json)
+tx WARNING:  -> ko_KR: public/locales/ko_KR/explore.json
+tx WARNING:  -> en: public/locales/en/explore.json
+...
+```
+
+- `-s` means "include the source file when pulling", which in our case is the `en` versions.
+- `-r ipld-explorer.explore-json` means just `explore.json` file. The mappings of resource name to files
+is in the `.tx/config` file.
+
+Now make your changes and add great keys and snappy `en` default values for them. When you are done, commit your changes as per usual. Changes to from master branch are fetched by Transifex automatically.

--- a/public/locales/README.md
+++ b/public/locales/README.md
@@ -1,0 +1,15 @@
+# IPFS Translation Project  🌐✍️🖖
+
+Thank you for caring about localization! You are a good person.
+
+We use [transifex.com](https://www.transifex.com/ipfs/public/) to manage translations. **Please don't edit the locale files directly.**
+
+- Go to https://www.transifex.com/ipfs/public/,
+- select languages can help with
+- Start translating!
+
+Once most of the text for the app is translated into a new language, the locale files are generated and added to this repo automatically.
+
+Please [open an issue](https://github.com/ipfs-shipyard/ipfs-webui/issues/new) if you'd like to help translate but something is not clear.
+
+See https://github.com/ipfs/i18n for more information.


### PR DESCRIPTION
Adds a `public/locales/README.md` as a notice to intrepid localizers that Transifex is the prefered way. Moves the technical details for developers into `docs/LOCALIZATION.md`

Seperate to this PR, i've also added issue templates, with a specific one about translation to make it extra obvious.

<img width="871" alt="screenshot 2019-02-18 at 12 41 18" src="https://user-images.githubusercontent.com/58871/52951878-e3a85f80-337a-11e9-8c73-4e3103147dbf.png">

Fixes #954 