### PR TITLE
fix: don't print out expected error

### DIFF
--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -57,13 +57,13 @@ bundle.reactConfigFetch = createSelector(
 )
 
 function getURLFromAddress (name, config) {
+  if (!config) return null
+
   try {
     const address = config.Addresses[name]
     return toUri(address).replace('tcp://', 'http://')
   } catch (error) {
-    if (config) {
-      console.log(`Failed to get url from Addresses.${name}`, error)
-    }
+    console.log(`Failed to get url from Addresses.${name}`, error)
     return null
   }
 }

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -60,7 +60,10 @@ function getURLFromAddress (name, config) {
   try {
     const address = config.Addresses[name]
     return toUri(address).replace('tcp://', 'http://')
-  } catch (_) {
+  } catch (error) {
+    if (config) {
+      console.log(`Failed to get url from Addresses.${name}`, error)
+    }
     return null
   }
 }

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -60,8 +60,7 @@ function getURLFromAddress (name, config) {
   try {
     const address = config.Addresses[name]
     return toUri(address).replace('tcp://', 'http://')
-  } catch (error) {
-    console.log(`Failed to get url from Addresses.${name}`, error)
+  } catch (_) {
     return null
   }
 }


### PR DESCRIPTION
Fixes #966 by not printing the error. That's an expected error in that function. We could also make the function receive an `expectsFailure` boolean variable which would tell whether or not to print the error.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>