### PR TITLE
fix: ensure we have a full api available

### DIFF
--- a/src/bundles/index.js
+++ b/src/bundles/index.js
@@ -29,7 +29,12 @@ export default composeBundles(
   createCacheBundle(bundleCache.set),
   appIdle({ idleTimeout: 5000 }),
   ipfsBundle({
-    tryWindow: false
+    tryWindow: false,
+    ipfsConnectionTest: (ipfs) => {
+      // ipfs connection is working if can we fetch the bw stats.
+      // See: https://github.com/ipfs-shipyard/ipfs-webui/issues/835#issuecomment-466966884
+      return ipfs.stats.bw()
+    }
   }),
   identityBundle,
   navbarBundle,

--- a/test/e2e/navigation.test.js
+++ b/test/e2e/navigation.test.js
@@ -1,7 +1,6 @@
 /* global it expect beforeAll afterAll */
 import ms from 'milliseconds'
 import { launch, appUrl } from './puppeteer'
-import fakeBandwidth from '../helpers/bandwidth'
 
 let browser
 
@@ -60,7 +59,7 @@ function addMockIpfs (page) {
         stat: () => Promise.resolve({})
       },
       stats: {
-        bw: () => Promise.resolve(fakeBandwidth()),
+        bw: () => Promise.resolve({ totalIn: 10, totalOut: 11, rateIn: 12, rateOut: 13 }),
         repo: () => Promise.resolve({}),
         bitswap: () => Promise.resolve({})
       },


### PR DESCRIPTION
- fixes issue where a readonly api would fool us into thinking we have a full api. If you look at https://webui.ipfs.io right now, you'll find it can't find your local ipfs daemon, as it finds the one provided by the domain first.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>