### PR TITLE
fix: file add error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:1.1
+      - image: olizilla/ipfs-dns-deploy:latest
         environment:
           DOMAIN: webui.ipfs.io
           BUILD_DIR: build

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -92,7 +92,7 @@ const createAnalyticsBundle = ({
       const EventMap = new Map()
       return next => action => {
         // Record durations for async actions
-        if (ASYNC_ACTION_RE.test(action.type)) {
+        if (ASYNC_ACTION_RE.test(action.type) && ASYNC_ACTION_STATE_RE.test(action.type)) {
           const [_, name, state] = ASYNC_ACTION_STATE_RE.exec(action.type) // eslint-disable-line no-unused-vars
           if (state === 'STARTED') {
             EventMap.set(name, root.performance.now())


### PR DESCRIPTION
The analytics upgrade switched around the regex logic for identifying
action types. The FILES_WRITE_UPDATED action passes the first regex
but doesn't pass the async state regex, which we then exec, which throws.

This is fixed by testing for both before exec-ing.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>