### PR TITLE
fix: get drop dir working again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7784,6 +7784,11 @@
         }
       }
     },
+    "datatransfer-files-promise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/datatransfer-files-promise/-/datatransfer-files-promise-1.2.0.tgz",
+      "integrity": "sha512-M853WpHN6CG/6llqz3clGl9Z3dZG/3he1NR2p0H0xNPM0ZMb+3DWQGMIK+3WTIm3odPKalWeXjRCmpcwjfDzrA=="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cids": "^0.6.0",
     "countly-sdk-web": "^19.2.1",
     "d3": "^5.7.0",
+    "datatransfer-files-promise": "^1.2.0",
     "details-polyfill": "^1.1.0",
     "file-extension": "^4.0.5",
     "filesize": "^3.6.1",

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ export class App extends Component {
     this.props.doInitIpfs()
   }
 
-  addFiles = (files) => {
+  addFiles = async (files) => {
     const { doFilesWrite, doUpdateHash, routeInfo } = this.props
 
     // Add the dropped files to the root
@@ -84,10 +84,8 @@ const dropTarget = {
     if (monitor.didDrop()) {
       return
     }
-
-    const item = monitor.getItem()
-
-    App.addFiles(item)
+    const { filesPromise } = monitor.getItem()
+    App.addFiles(filesPromise)
   }
 }
 

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -246,7 +246,7 @@ export default (opts = {}) => {
     },
 
     doFilesWrite: make(actions.WRITE, async (ipfs, root, filesOrPromise, id, { dispatch }) => {
-      let files = filesOrPromise.then ? await filesOrPromise : filesOrPromise
+      let files = await filesOrPromise
       const { streams, totalSize } = await filesToStreams(files)
 
       // Normalise all paths to be relative. Dropped files come as absolute,

--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -152,7 +152,7 @@ const dropTarget = {
     const item = monitor.getItem()
 
     if (item.hasOwnProperty('files')) {
-      props.onAddFiles(item, props.path)
+      props.onAddFiles(item.filesPromise, props.path)
     } else {
       const src = item.path
       const dst = join(props.path, basename(item.path))

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -495,10 +495,8 @@ const dropTarget = {
     if (monitor.didDrop()) {
       return
     }
-
-    const item = monitor.getItem()
-
-    onAddFiles(item)
+    const { filesPromise } = monitor.getItem()
+    onAddFiles(filesPromise)
   }
 }
 

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -8,11 +8,6 @@ const ignore = [
 ]
 
 export async function filesToStreams (files) {
-  if (files.hasOwnProperty('content')) {
-    // this is a promise
-    return files.content
-  }
-
   const streams = []
   let totalSize = 0
   let isDir = false
@@ -29,14 +24,14 @@ export async function filesToStreams (files) {
     }
 
     streams.push({
-      path: file.webkitRelativePath || file.name,
+      path: file.filepath || file.webkitRelativePath || file.name,
       content: stream,
       size: file.size
     })
 
     totalSize += file.size
   }
-
+  console.log('input', { files, streams, totalSize, isDir })
   return { streams, totalSize, isDir }
 }
 

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -31,7 +31,6 @@ export async function filesToStreams (files) {
 
     totalSize += file.size
   }
-  console.log('input', { files, streams, totalSize, isDir })
   return { streams, totalSize, isDir }
 }
 


### PR DESCRIPTION
- replace our directory walking code with https://github.com/grabantot/datatransfer-files-promise#readme
- normalise the logic so adding via fileinput and drop both go
through the filesToStreams logic.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>