### PR TITLE
fix: handle file-drop inside empty dir

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,12 +35,11 @@ export class App extends Component {
 
   addFiles = async (files) => {
     const { doFilesWrite, doUpdateHash, routeInfo } = this.props
-
-    // Add the dropped files to the root
-    doFilesWrite('/', files)
-
+    const isFilesPage = routeInfo.pattern === '/files*'
+    const addAtPath = isFilesPage ? routeInfo.params.path : '/'
+    doFilesWrite(addAtPath, files)
     // Change to the files pages if the user is not there
-    if (!routeInfo.url.startsWith('/files')) {
+    if (!isFilesPage) {
       doUpdateHash('/files')
     }
   }


### PR DESCRIPTION
if you drop files inside dirs that have zero or fewer items than
fills the vertical height, the drop would land on the app rather
than the file list, which would cause files dropped inside the dir
to be added at the root rather than the dir.

This PR is a quick fix to ensure the drops handled at the app level
add the files to the current dir where we are on the files page.

| Before | After |
|--------|------|
| ![webui-drop-on-empty-dir-before](https://user-images.githubusercontent.com/58871/56651668-7ddd9a00-6681-11e9-93da-8b468ff4c370.gif) | ![webui-drop-on-empty-dir-after](https://user-images.githubusercontent.com/58871/56651677-8635d500-6681-11e9-8ad8-902c37a49a52.gif)



License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>