### PR TITLE
fix: useless list re-renders

### DIFF
--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -48,6 +48,7 @@ const defaultState = {
 
 class FilesPage extends React.Component {
   static propTypes = {
+    ipfsConnected: PropTypes.bool,
     ipfsProvider: PropTypes.string,
     files: PropTypes.object,
     filesErrors: PropTypes.array,
@@ -83,7 +84,7 @@ class FilesPage extends React.Component {
   componentDidUpdate (prev) {
     const { filesPathFromHash } = this.props
 
-    if (prev.files === null || filesPathFromHash !== prev.filesPathFromHash) {
+    if (prev.files === null || !prev.ipfsConnected || filesPathFromHash !== prev.filesPathFromHash) {
       this.props.doFilesFetch()
     }
   }
@@ -377,6 +378,7 @@ const WelcomeInfo = ({ t }) => (
 
 export default connect(
   'selectIpfsProvider',
+  'selectIpfsConnected',
   'doUpdateHash',
   'doFilesDelete',
   'doFilesMove',


### PR DESCRIPTION
Fixes the useless _tons_ of re-renders on file pages. It happened because every time we returned from `selectFiles`, we were sorting at the time and using the spread operator, hence creating a new _different_  object, causing a re-render. Now it just changes when the files are fetched _and_ when the sorting is updated.

Also, fixed the issue where you open the Web UI on files page and it just wouldn't load.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>