### PR TITLE
refactor: cleanup files page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3486,12 +3486,9 @@
       }
     },
     "@tableflip/react-dropdown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@tableflip/react-dropdown/-/react-dropdown-1.2.0.tgz",
-      "integrity": "sha512-yn9vcXvgITQceGHE4pAkuwEMos8H3cyaDfVYQVwP0raAMML5U0DDMOj4CANus78HwWTFgM9vNY8TIUVxkhuBPA==",
-      "requires": {
-        "tachyons": "^4.10.0"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tableflip/react-dropdown/-/react-dropdown-1.3.0.tgz",
+      "integrity": "sha512-Cm2bK5viLNx6/mrz1b6OpWc2sKXgmBFfTBR/Tqr3wnOdTggD90n7si9HDcojdQ4PvLlo0CFDFUDpKzYnUUl32Q=="
     },
     "@tableflip/react-inspector": {
       "version": "2.3.0",
@@ -10905,8 +10902,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10924,13 +10920,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10943,18 +10937,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11057,8 +11048,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11068,7 +11058,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11081,20 +11070,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11111,7 +11097,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11184,8 +11169,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11195,7 +11179,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11271,8 +11254,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11302,7 +11284,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11320,7 +11301,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11359,13 +11339,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -12845,7 +12823,7 @@
         "bl": "^3.0.0",
         "bs58": "^4.0.1",
         "cids": "~0.5.5",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+        "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
         "debug": "^4.1.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
@@ -12867,7 +12845,7 @@
         "multibase": "~0.6.0",
         "multicodec": "~0.5.0",
         "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+        "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
         "once": "^1.4.0",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1",
@@ -23551,8 +23529,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -23570,13 +23547,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -23589,18 +23564,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -23703,8 +23675,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -23714,7 +23685,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -23727,20 +23697,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -23757,7 +23724,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -23830,8 +23796,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -23841,7 +23806,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -23917,8 +23881,7 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -23948,7 +23911,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -23966,7 +23928,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -24005,13 +23966,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-storybook": "build-storybook -s public"
   },
   "dependencies": {
-    "@tableflip/react-dropdown": "^1.2.0",
+    "@tableflip/react-dropdown": "^1.3.0",
     "@tableflip/react-inspector": "^2.3.0",
     "brace": "^0.11.1",
     "chart.js": "^2.7.2",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -71,7 +71,7 @@
     "paragraph6": "<0>If you want to help push the Web UI forward, <1>check out its code</1> or <3>report a bug</3>!</0>"
   },
   "filesList": {
-    "noFiles": "<0>No files in this directory. Click the “Add to IPFS” button to add some.</0>"
+    "noFiles": "<0>No files in this directory. Click the “Add” button to add some.</0>"
   },
   "addFilesInfo": "<0>Add files to your local IPFS node by clicking the <1>Add to IPFS</1> button above.</0>",
   "companionInfo": "<0>As you are using <1>IPFS Companion</1>, the files view is limited to files added while using the extension.</0>"

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -17,6 +17,7 @@
   "addByPath": "From IPFS",
   "addToIPFS": "Add",
   "newFolder": "New folder",
+  "generating": "Generating...",
   "actions": {
     "add": "Add",
     "delete": "Delete",

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -70,23 +70,14 @@ const fetchFiles = make(actions.FETCH, async (ipfs, id, { store }) => {
   const stats = await ipfs.files.stat(path)
 
   if (stats.type === 'file') {
-    stats.name = path
-
     return {
       path: path,
       fetched: Date.now(),
       type: 'file',
-      stats: stats,
       read: () => ipfs.files.read(path),
-      // TODO - This will be refactored in the future
-      // I'm adding this here to make the file actions work in preview mode
-      extra: [{
-        name: path.split('/').pop(),
-        path: path,
-        type: 'file',
-        size: stats.size,
-        hash: stats.hash
-      }]
+      name: path.split('/').pop(),
+      size: stats.size,
+      hash: stats.hash
     }
   }
 

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -6,19 +6,14 @@ import { connect } from 'redux-bundler-react'
 import downloadFile from './download-file'
 import { translate } from 'react-i18next'
 // Components
-import Breadcrumbs from './breadcrumbs/Breadcrumbs'
 import FilesList from './files-list/FilesList'
 import FilePreview from './file-preview/FilePreview'
-import FileInput from './file-input/FileInput'
 import ContextMenu from './context-menu/ContextMenu'
-import Button from '../components/button/Button'
 import AddFilesInfo from './info-boxes/AddFilesInfo'
 import CompanionInfo from './info-boxes/CompanionInfo'
 import WelcomeInfo from './info-boxes/WelcomeInfo'
 import Modals, { DELETE, NEW_FOLDER, SHARE, RENAME } from './modals/Modals'
-// Icons
-import GlyphDots from '../icons/GlyphDots'
-import FolderIcon from '../icons/StrokeFolder'
+import Header from './header/Header'
 
 const defaultState = {
   downloadAbort: null,
@@ -48,7 +43,6 @@ class FilesPage extends React.Component {
     filesErrors: PropTypes.array,
     filesPathFromHash: PropTypes.string,
     filesSorting: PropTypes.object.isRequired,
-    writeFilesProgress: PropTypes.number,
     gatewayUrl: PropTypes.string.isRequired,
     doUpdateHash: PropTypes.func.isRequired,
     doFilesDelete: PropTypes.func.isRequired,
@@ -170,14 +164,9 @@ class FilesPage extends React.Component {
     })
   }
 
-  handleSingleClick = (ev) => {
-    const dotsPosition = this.dotsWrapper.getBoundingClientRect()
-    this.handleContextMenu(ev, 'LEFT', this.props.files, dotsPosition)
-  }
-
   render () {
     const {
-      ipfsProvider, files, writeFilesProgress, filesSorting: sort, t,
+      ipfsProvider, files, filesSorting: sort, t,
       doFilesMove, doFilesNavigateTo, doFilesUpdateSorting
     } = this.props
 
@@ -210,31 +199,10 @@ class FilesPage extends React.Component {
 
         { files &&
           <div>
-            <div className='flex flex-wrap items-center mb3'>
-              <Breadcrumbs path={files.path} onClick={doFilesNavigateTo} />
-
-              { files.type === 'directory'
-                ? (
-                  <div className='ml-auto flex items-center'>
-                    <Button
-                      className='mr3 f6 pointer'
-                      color='charcoal-muted'
-                      bg='bg-transparent'
-                      onClick={() => this.showNewFolderModal()}>
-                      <FolderIcon viewBox='10 15 80 80' height='20px' className='fill-charcoal-muted w2 v-mid' />
-                      <span className='fw3'>{t('newFolder')}</span>
-                    </Button>
-                    <FileInput
-                      onAddFiles={this.add}
-                      onAddByPath={this.addByPath}
-                      addProgress={writeFilesProgress} />
-                  </div>
-                ) : (
-                  <div ref={el => { this.dotsWrapper = el }} className='ml-auto' style={{ width: '1.5rem' }}> {/* to render correctly in Firefox */}
-                    <GlyphDots className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.handleSingleClick} />
-                  </div>
-                )}
-            </div>
+            <Header onAdd={this.add}
+              onAddByPath={this.addByPath}
+              onNewFolder={this.showNewFolderModal}
+              handleContextMenu={this.handleContextMenu} />
 
             { isRoot && isCompanion && <CompanionInfo /> }
 
@@ -278,14 +246,12 @@ export default connect(
   'doFilesWrite',
   'doFilesAddPath',
   'doFilesDownloadLink',
-  'doFilesShareLink',
   'doFilesMakeDir',
   'doFilesFetch',
   'doFilesNavigateTo',
   'doFilesUpdateSorting',
   'selectFiles',
   'selectGatewayUrl',
-  'selectWriteFilesProgress',
   'selectFilesPathFromHash',
   'selectFilesSorting',
   translate('files')(FilesPage)

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -131,7 +131,7 @@ class FilesPage extends React.Component {
     this.setState({ modals: { } })
   }
 
-  handleContextMenu = (ev, clickType, file, dotsPosition) => {
+  handleContextMenu = (ev, clickType, file, dotsPosition, fromHeader = false) => {
     // This is needed to disable the native OS right-click menu
     // and deal with the clicking on the ContextMenu options
     if (ev !== undefined && typeof ev !== 'string') {
@@ -147,10 +147,15 @@ class FilesPage extends React.Component {
 
     if (clickType === 'RIGHT') {
       const rightPadding = window.innerWidth - ctxMenu.parentNode.getBoundingClientRect().right
-      translateX = (window.innerWidth - ev.clientX) - rightPadding - 15
+      translateX = (window.innerWidth - ev.clientX) - rightPadding - 20
       translateY = (ctxMenuPosition.y + ctxMenuPosition.height / 2) - ev.clientY - 10
     } else {
+      translateX = 1
       translateY = (ctxMenuPosition.y + ctxMenuPosition.height / 2) - (dotsPosition && dotsPosition.y) - 30
+    }
+
+    if (fromHeader) {
+      translateX = -8
     }
 
     this.setState({
@@ -201,7 +206,7 @@ class FilesPage extends React.Component {
             <Header onAdd={this.add}
               onAddByPath={this.addByPath}
               onNewFolder={this.showNewFolderModal}
-              handleContextMenu={this.handleContextMenu} />
+              handleContextMenu={(...args) => this.handleContextMenu(...args, true)} />
 
             { isRoot && isCompanion && <CompanionInfo /> }
 

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -27,8 +27,7 @@ const defaultState = {
     translateX: 0,
     translateY: 0,
     file: null
-  },
-  isContextMenuOpen: false
+  }
 }
 
 class FilesPage extends React.Component {

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -14,6 +14,7 @@ import CompanionInfo from './info-boxes/CompanionInfo'
 import WelcomeInfo from './info-boxes/WelcomeInfo'
 import Modals, { DELETE, NEW_FOLDER, SHARE, RENAME } from './modals/Modals'
 import Header from './header/Header'
+import { prefix } from 'multihashes';
 
 const defaultState = {
   downloadAbort: null,
@@ -68,6 +69,10 @@ class FilesPage extends React.Component {
 
     if (prev.files === null || filesPathFromHash !== prev.filesPathFromHash) {
       this.props.doFilesFetch()
+    }
+
+    if (prev.files && prev.files.path !== this.props.files.path) {
+      this.setState({ contextMenu: defaultState.contextMenu })
     }
   }
 

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -177,12 +177,12 @@ class FilesPage extends React.Component {
                     <ContextMenu
                       handleClick={this.handleContextMenuClick}
                       isOpen={this.state.isContextMenuOpen}
-                      onShare={() => this.showShareModal(files.extra)}
-                      onDelete={() => this.showDeleteModal(files.extra)}
-                      onRename={() => this.showRenameModal(files.extra)}
-                      onInspect={() => this.inspect(files.extra)}
-                      onDownload={() => this.download(files.extra)}
-                      hash={files.stats.hash} />
+                      onShare={() => this.showShareModal([files])}
+                      onDelete={() => this.showDeleteModal([files])}
+                      onRename={() => this.showRenameModal([files])}
+                      onInspect={() => this.inspect([files])}
+                      onDownload={() => this.download([files])}
+                      hash={files.hash} />
                   </div>
                 )}
             </div>

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -14,7 +14,6 @@ import CompanionInfo from './info-boxes/CompanionInfo'
 import WelcomeInfo from './info-boxes/WelcomeInfo'
 import Modals, { DELETE, NEW_FOLDER, SHARE, RENAME } from './modals/Modals'
 import Header from './header/Header'
-import { prefix } from 'multihashes';
 
 const defaultState = {
   downloadAbort: null,

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -70,10 +70,6 @@ class FilesPage extends React.Component {
     if (prev.files === null || filesPathFromHash !== prev.filesPathFromHash) {
       this.props.doFilesFetch()
     }
-
-    if (prev.files && prev.files.path !== this.props.files.path) {
-      this.setState({ contextMenu: defaultState.contextMenu })
-    }
   }
 
   download = async (files) => {

--- a/src/files/context-menu/ContextMenu.js
+++ b/src/files/context-menu/ContextMenu.js
@@ -61,7 +61,7 @@ class ContextMenu extends React.Component {
         <DropdownMenu
           top={-8}
           arrowMarginRight='11px'
-          left='calc(100% - 200px + 0.5rem)'
+          left='calc(100% - 200px)'
           translateX={-translateX}
           translateY={-translateY}
           open={this.props.isOpen}

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -7,7 +7,9 @@ import ComponentLoader from '../../loader/ComponentLoader.js'
 
 class FilesPreview extends React.Component {
   static propTypes = {
-    stats: PropTypes.object.isRequired,
+    hash: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    size: PropTypes.number.isRequired,
     gatewayUrl: PropTypes.string.isRequired,
     read: PropTypes.func.isRequired,
     content: PropTypes.object,
@@ -25,10 +27,10 @@ class FilesPreview extends React.Component {
   }
 
   render () {
-    const { t, stats, gatewayUrl } = this.props
+    const { t, name, size, hash, gatewayUrl } = this.props
 
-    const type = typeFromExt(stats.name)
-    const src = `${gatewayUrl}/ipfs/${stats.hash}`
+    const type = typeFromExt(name)
+    const src = `${gatewayUrl}/ipfs/${hash}`
     const className = 'mw-100 mt3 bg-snow-muted pa2 br2'
 
     switch (type) {
@@ -52,7 +54,7 @@ class FilesPreview extends React.Component {
           </video>
         )
       case 'image':
-        return <img className={className} alt={stats.name} src={src} />
+        return <img className={className} alt={name} src={src} />
       default:
         const cantPreview = (
           <div className='mt4'>
@@ -65,7 +67,7 @@ class FilesPreview extends React.Component {
           </div>
         )
 
-        if (stats.size > 1024 * 1024 * 4) {
+        if (size > 1024 * 1024 * 4) {
           return cantPreview
         }
 

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -14,14 +14,12 @@ import { DropTarget } from 'react-dnd'
 // Components
 import Checkbox from '../../components/checkbox/Checkbox'
 import SelectedActions from '../selected-actions/SelectedActions'
-import ContextMenu from '../context-menu/ContextMenu'
 import File from '../file/File'
 import LoadingAnimation from '../../components/loading-animation/LoadingAnimation'
 
 export class FilesList extends React.Component {
   constructor (props) {
     super(props)
-    this.contextMenuRef = React.createRef()
     this.listRef = React.createRef()
   }
 
@@ -63,13 +61,7 @@ export class FilesList extends React.Component {
     selected: [],
     focused: null,
     firstVisibleRow: null,
-    isDragging: false,
-    contextMenu: {
-      isOpen: false,
-      translateX: 0,
-      translateY: 0,
-      currentFile: null
-    }
+    isDragging: false
   }
 
   filesRefs = {}
@@ -118,30 +110,6 @@ export class FilesList extends React.Component {
         count={this.state.selected.length}
         downloadProgress={this.props.downloadProgress}
         size={size} />
-    )
-  }
-
-  get contextMenu () {
-    const { contextMenu } = this.state
-    const isUpperDir = contextMenu.currentFile && contextMenu.currentFile.type === 'directory' && contextMenu.currentFile.name === '..'
-
-    return (
-      <div className='ph2 pv1 relative' style={{ width: '2.5rem' }}>
-        <ContextMenu
-          ref={this.contextMenuRef}
-          isOpen={contextMenu.isOpen}
-          translateX={contextMenu.translateX}
-          translateY={contextMenu.translateY}
-          handleClick={this.handleContextMenuClick}
-          isUpperDir={isUpperDir}
-          showDots={false}
-          onShare={() => this.props.onShare([contextMenu.currentFile])}
-          onDelete={() => this.props.onDelete([contextMenu.currentFile])}
-          onRename={() => this.props.onRename([contextMenu.currentFile])}
-          onInspect={() => this.props.onInspect([contextMenu.currentFile])}
-          onDownload={() => this.props.onDownload([contextMenu.currentFile])}
-          hash={contextMenu.currentFile && contextMenu.currentFile.hash} />
-      </div>
     )
   }
 
@@ -322,7 +290,7 @@ export class FilesList extends React.Component {
           onAddFiles={onAddFiles}
           onMove={this.move}
           setIsDragging={this.isDragging}
-          handleContextMenuClick={this.handleContextMenuClick}
+          handleContextMenuClick={this.props.handleContextMenuClick}
           translucent={isDragging || (isOver && canDrop)}
           name='..'
           focused={focused === '..'}
@@ -354,7 +322,7 @@ export class FilesList extends React.Component {
               onAddFiles={onAddFiles}
               onMove={this.move}
               setIsDragging={this.isDragging}
-              handleContextMenuClick={this.handleContextMenuClick}
+              handleContextMenuClick={this.props.handleContextMenuClick}
               translucent={isDragging || (isOver && canDrop)}
               name='..'
               focused={focused === '..'}
@@ -381,49 +349,13 @@ export class FilesList extends React.Component {
           focused={focused === files[index].name}
           selected={selected.indexOf(files[index].name) !== -1}
           setIsDragging={this.isDragging}
-          handleContextMenuClick={this.handleContextMenuClick}
+          handleContextMenuClick={this.props.handleContextMenuClick}
           translucent={isDragging || (isOver && canDrop)} />
       </div>
     )
   }
 
   onRowsRendered = ({ startIndex }) => this.setState({ firstVisibleRow: startIndex })
-
-  handleContextMenuClick = (ev, clickType, file, dotsPosition) => {
-    // This is needed to disable the native OS right-click menu
-    // and deal with the clicking on the ContextMenu options
-    if (ev !== undefined && typeof ev !== 'string') {
-      ev.preventDefault()
-      ev.persist()
-    }
-
-    const ctxMenu = findDOMNode(this.contextMenuRef.current)
-    const ctxMenuPosition = ctxMenu.getBoundingClientRect()
-
-    if (clickType === 'RIGHT') {
-      this.setState(state => ({
-        ...state,
-        contextMenu: {
-          ...state.contextMenu,
-          isOpen: !state.contextMenu.isOpen,
-          translateX: (ctxMenuPosition.x + ctxMenuPosition.width / 2) - ev.clientX,
-          translateY: (ctxMenuPosition.y + ctxMenuPosition.height / 2) - ev.clientY - 10,
-          currentFile: file
-        }
-      }))
-    } else {
-      this.setState(state => ({
-        ...state,
-        contextMenu: {
-          ...state.contextMenu,
-          isOpen: !state.contextMenu.isOpen,
-          translateX: (ctxMenuPosition.x + ctxMenuPosition.width / 2) - (dotsPosition && dotsPosition.x) - 19,
-          translateY: (ctxMenuPosition.y + ctxMenuPosition.height / 2) - (dotsPosition && dotsPosition.y) - 30,
-          currentFile: file
-        }
-      }))
-    }
-  }
 
   render () {
     let { t, files, className, upperDir, showLoadingAnimation, connectDropTarget } = this.props
@@ -482,7 +414,6 @@ export class FilesList extends React.Component {
                 </div>
               )}
             </WindowScroller>
-            {this.contextMenu}
             {this.selectedMenu}
           </Fragment> }
       </section>

--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { connect } from 'redux-bundler-react'
+import { translate } from 'react-i18next'
+// Components
+import Breadcrumbs from '../breadcrumbs/Breadcrumbs'
+import FileInput from '../file-input/FileInput'
+import Button from '../../components/button/Button'
+// Icons
+import GlyphDots from '../../icons/GlyphDots'
+import FolderIcon from '../../icons/StrokeFolder'
+
+class Header extends React.Component {
+  handleContextMenu = (ev) => {
+    const dotsPosition = this.dotsWrapper.getBoundingClientRect()
+    this.props.handleContextMenu(ev, 'LEFT', this.props.files, dotsPosition)
+  }
+
+  render () {
+    const {
+      files, writeFilesProgress, t,
+      doFilesNavigateTo
+    } = this.props
+
+    return (
+      <div className='flex flex-wrap items-center mb3'>
+        <Breadcrumbs path={files.path} onClick={doFilesNavigateTo} />
+
+        { files.type === 'directory'
+          ? (
+            <div className='ml-auto flex items-center'>
+              <Button
+                className='mr3 f6 pointer'
+                color='charcoal-muted'
+                bg='bg-transparent'
+                onClick={this.props.onNewFolder}>
+                <FolderIcon viewBox='10 15 80 80' height='20px' className='fill-charcoal-muted w2 v-mid' />
+                <span className='fw3'>{t('newFolder')}</span>
+              </Button>
+              <FileInput
+                onAddFiles={this.props.onAdd}
+                onAddByPath={this.props.onAddByPath}
+                addProgress={writeFilesProgress} />
+            </div>
+          ) : (
+            <div ref={el => { this.dotsWrapper = el }} className='ml-auto' style={{ width: '1.5rem' }}> {/* to render correctly in Firefox */}
+              <GlyphDots className='fill-gray-muted pointer hover-fill-gray transition-all' onClick={this.handleContextMenu} />
+            </div>
+          )}
+      </div>
+    )
+  }
+}
+
+export default connect(
+  'doFilesNavigateTo',
+  'selectFiles',
+  'selectWriteFilesProgress',
+  translate('files')(Header)
+)

--- a/src/files/info-boxes/AddFilesInfo.js
+++ b/src/files/info-boxes/AddFilesInfo.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { connect } from 'redux-bundler-react'
+import { translate, Trans } from 'react-i18next'
+import Box from '../../components/box/Box'
+
+const AddFilesInfo = () => (
+  <div className='mv4 tc navy f5' >
+    <Box style={{ background: 'rgba(105, 196, 205, 0.1)' }}>
+      <Trans i18nKey='addFilesInfo'>
+        <p className='ma0'>Add files to your local IPFS node by clicking the <strong>Add to IPFS</strong> button above.</p>
+      </Trans>
+    </Box>
+  </div>
+)
+
+export default connect(translate('files')(AddFilesInfo))

--- a/src/files/info-boxes/CompanionInfo.js
+++ b/src/files/info-boxes/CompanionInfo.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { connect } from 'redux-bundler-react'
+import { translate, Trans } from 'react-i18next'
+import Box from '../../components/box/Box'
+
+const CompanionInfo = () => (
+  <div className='mv4 tc navy f5' >
+    <Box style={{ background: 'rgba(105, 196, 205, 0.1)' }}>
+      <Trans i18nKey='companionInfo'>
+        <p className='ma0'>As you are using <strong>IPFS Companion</strong>, the files view is limited to files added while using the extension.</p>
+      </Trans>
+    </Box>
+  </div>
+)
+
+export default connect(translate('files')(CompanionInfo))

--- a/src/files/info-boxes/WelcomeInfo.js
+++ b/src/files/info-boxes/WelcomeInfo.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { connect } from 'redux-bundler-react'
+import { translate, Trans } from 'react-i18next'
+import AboutIpfs from '../../components/about-ipfs/AboutIpfs'
+import Box from '../../components/box/Box'
+
+const WelcomeInfo = ({ t }) => (
+  <div className='flex'>
+    <div className='flex-auto pr3 lh-copy mid-gray'>
+      <Box>
+        <h1 className='mt0 mb3 montserrat fw4 f4 charcoal'>{t('welcomeInfo.header')}</h1>
+        <Trans i18nKey='welcomeInfo.paragraph1'>
+          <p className='f5'><a href='#/' className='link blue u b'>Check the status</a> of your node, it's Peer ID and connection info, the network traffic and the number of connected peers.</p>
+        </Trans>
+        <Trans i18nKey='welcomeInfo.paragraph2'>
+          <p className='f5'>Easily <a href='#/files' className='link blue b'>manage files</a> in your IPFS repo. You can drag and drop to add files, move and rename them, delete, share or download them.</p>
+        </Trans>
+        <Trans i18nKey='welcomeInfo.paragraph3'>
+          <p className='f5'>You can <a href='#/explore' className='link blue b'>explore IPLD data</a> that underpins how IPFS works.</p>
+        </Trans>
+        <Trans i18nKey='welcomeInfo.paragraph4'>
+          <p className='f5'>See all of your <a href='#/peers' className='link blue b'>connected peers</a>, geolocated by their IP address.</p>
+        </Trans>
+        <Trans i18nKey='welcomeInfo.paragraph5'>
+          <p className='mb4 f5'><a href='#/settings' className='link blue b'>Review the settings</a> for your IPFS node, and update them to better suit your needs.</p>
+        </Trans>
+        <Trans i18nKey='welcomeInfo.paragraph6'>
+          <p className='mb0 f5'>If you want to help push the Web UI forward, <a href='https://github.com/ipfs-shipyard/ipfs-webui' className='link blue'>check out its code</a> or <a href='https://github.com/ipfs-shipyard/ipfs-webui/issues' className='link blue'>report a bug</a>!</p>
+        </Trans>
+      </Box>
+    </div>
+    <div className='measure lh-copy dn db-l flex-none mid-gray f6' style={{ maxWidth: '40%' }}>
+      <AboutIpfs />
+    </div>
+  </div>
+)
+
+export default connect(translate('files')(WelcomeInfo))

--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -1,0 +1,170 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'redux-bundler-react'
+import { join } from 'path'
+import { translate } from 'react-i18next'
+import Overlay from '../../components/overlay/Overlay'
+import NewFolderModal from './new-folder-modal/NewFolderModal'
+import ShareModal from './share-modal/ShareModal'
+import RenameModal from './rename-modal/RenameModal'
+import DeleteModal from './delete-modal/DeleteModal'
+
+const NEW_FOLDER = 'new_folder'
+const SHARE = 'share'
+const RENAME = 'rename'
+const DELETE = 'delete'
+
+export {
+  NEW_FOLDER,
+  SHARE,
+  RENAME,
+  DELETE
+}
+
+class Modals extends React.Component {
+  static propTypes = {
+    t: PropTypes.func,
+    show: PropTypes.string,
+    files: PropTypes.array,
+    doFilesMove: PropTypes.func,
+    doFilesMakeDir: PropTypes.func,
+    doFilesShareLink: PropTypes.func,
+    doFilesDelete: PropTypes.func
+  }
+
+  state = {
+    readyToShow: false,
+    rename: {
+      folder: false,
+      path: '',
+      filename: ''
+    },
+    delete: {
+      files: 0,
+      folder: 0,
+      paths: []
+    },
+    link: ''
+  }
+
+  makeDir = (path) => {
+    const { doFilesMakeDir, root } = this.props
+
+    doFilesMakeDir(join(root, path))
+    this.leave()
+  }
+
+  rename = (newName) => {
+    const { filename, path } = this.state.rename
+    const { doFilesMove } = this.props
+
+    if (newName !== '' && newName !== filename) {
+      doFilesMove([path, path.replace(filename, newName)])
+    }
+
+    this.leave()
+  }
+
+  delete = () => {
+    const { paths } = this.state.delete
+
+    this.props.doFilesDelete(paths)
+    this.leave()
+  }
+
+  leave = () => {
+    this.setState({ readyToShow: false })
+    this.props.done()
+  }
+
+  componentDidUpdate (prev) {
+    const { show, files, t, doFilesShareLink } = this.props
+
+    if (show === prev.show) {
+      return
+    }
+
+    if (show === SHARE) {
+      this.setState({
+        link: t('generating'),
+        readyToShow: true
+      })
+
+      doFilesShareLink(files).then(link => this.setState({ link }))
+    } else if (show === RENAME) {
+      const file = files[0]
+
+      this.setState({
+        readyToShow: true,
+        rename: {
+          folder: file.type === 'directory',
+          path: file.path,
+          filename: file.path.split('/').pop()
+        }
+      })
+    } else if (show === DELETE) {
+      let filesCount = 0
+      let foldersCount = 0
+
+      files.forEach(file => file.type === 'file' ? filesCount++ : foldersCount++)
+
+      this.setState({
+        readyToShow: true,
+        delete: {
+          files: filesCount,
+          folders: foldersCount,
+          paths: files.map(f => f.path)
+        }
+      })
+    } else {
+      this.setState({ readyToShow: true })
+    }
+  }
+
+  render () {
+    const { show } = this.props
+    const { readyToShow, link, rename } = this.state
+
+    return (
+      <div>
+        <Overlay show={show === NEW_FOLDER && readyToShow} onLeave={this.leave}>
+          <NewFolderModal
+            className='outline-0'
+            onCancel={this.leave}
+            onSubmit={this.makeDir} />
+        </Overlay>
+
+        <Overlay show={show === SHARE && readyToShow} onLeave={this.leave}>
+          <ShareModal
+            className='outline-0'
+            link={link}
+            onLeave={this.leave} />
+        </Overlay>
+
+        <Overlay show={show === RENAME && readyToShow} onLeave={this.leave}>
+          <RenameModal
+            className='outline-0'
+            { ...rename }
+            onCancel={this.leave}
+            onSubmit={this.rename} />
+        </Overlay>
+
+        <Overlay show={show === DELETE && readyToShow} onLeave={this.leave}>
+          <DeleteModal
+            className='outline-0'
+            { ...this.state.delete }
+            onCancel={this.leave}
+            onDelete={this.delete} />
+        </Overlay>
+      </div>
+    )
+  }
+}
+
+export default connect(
+  'doFilesMove',
+  'doFilesMakeDir',
+  'doFilesShareLink',
+  'doFilesDelete',
+  translate('files')(Modals)
+)

--- a/src/files/modals/delete-modal/DeleteModal.js
+++ b/src/files/modals/delete-modal/DeleteModal.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
-import TrashIcon from '../../icons/StrokeTrash'
-import Button from '../../components/button/Button'
-import { Modal, ModalActions, ModalBody } from '../../components/modal/Modal'
+import TrashIcon from '../../../icons/StrokeTrash'
+import Button from '../../../components/button/Button'
+import { Modal, ModalActions, ModalBody } from '../../../components/modal/Modal'
 
 const DeleteModal = ({ t, tReady, onCancel, onDelete, folders, files, className, ...props }) => {
   let context = 'File'

--- a/src/files/modals/delete-modal/DeleteModal.stories.js
+++ b/src/files/modals/delete-modal/DeleteModal.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
-import i18n from '../../i18n-decorator'
+import i18n from '../../../i18n-decorator'
 import DeleteModal from './DeleteModal'
 
 storiesOf('Files', module)

--- a/src/files/modals/new-folder-modal/NewFolderModal.js
+++ b/src/files/modals/new-folder-modal/NewFolderModal.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'react-i18next'
-import FolderIcon from '../../icons/StrokeFolder'
-import TextInputModal from '../../components/text-input-modal/TextInputModal'
+import FolderIcon from '../../../icons/StrokeFolder'
+import TextInputModal from '../../../components/text-input-modal/TextInputModal'
 
 function NewFolderModal ({ t, tReady, onCancel, onSubmit, className, ...props }) {
   return (

--- a/src/files/modals/rename-modal/RenameModal.js
+++ b/src/files/modals/rename-modal/RenameModal.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import PencilIcon from '../../icons/StrokePencil'
-import TextInputModal from '../../components/text-input-modal/TextInputModal'
+import PencilIcon from '../../../icons/StrokePencil'
+import TextInputModal from '../../../components/text-input-modal/TextInputModal'
 import { translate } from 'react-i18next'
 
 function RenameModal ({ t, tReady, onCancel, onSubmit, filename, folder, className, ...props }) {

--- a/src/files/modals/rename-modal/RenameModal.stories.js
+++ b/src/files/modals/rename-modal/RenameModal.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
-import i18n from '../../i18n-decorator'
+import i18n from '../../../i18n-decorator'
 import RenameModal from './RenameModal'
 
 storiesOf('Files', module)

--- a/src/files/modals/share-modal/ShareModal.js
+++ b/src/files/modals/share-modal/ShareModal.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import ShareIcon from '../../icons/StrokeShare'
-import Button from '../../components/button/Button'
+import ShareIcon from '../../../icons/StrokeShare'
+import Button from '../../../components/button/Button'
 import { translate } from 'react-i18next'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
-import { Modal, ModalActions, ModalBody } from '../../components/modal/Modal'
+import { Modal, ModalActions, ModalBody } from '../../../components/modal/Modal'
 
 const ShareModal = ({ t, tReady, onLeave, link, className, ...props }) => (
   <Modal {...props} className={className} onCancel={onLeave} >

--- a/src/files/modals/share-modal/ShareModal.stories.js
+++ b/src/files/modals/share-modal/ShareModal.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import i18n from '../../i18n-decorator'
+import i18n from '../../../i18n-decorator'
 import ShareModal from './ShareModal'
 
 storiesOf('Files', module)


### PR DESCRIPTION
This declutters the `FilesPage` file a lot.

- Moves the modals to their own directory and the info boxes to their own directory too 5409447
- Cleans up files.extra on preview c2055cc
- Quickly fixes a message f8a3059
- Cleans up context menu 63b4164
- Moves header outside of files page ea6b761

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>