### PR TITLE
refactor: cleans up files.extra on preview

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -70,7 +70,7 @@
     "paragraph6": "<0>If you want to help push the Web UI forward, <1>check out its code</1> or <3>report a bug</3>!</0>"
   },
   "filesList": {
-    "noFiles": "<0>No files in this directory. Click the “Add to IPFS” button to add some.</0>"
+    "noFiles": "<0>No files in this directory. Click the “Add” button to add some.</0>"
   },
   "addFilesInfo": "<0>Add files to your local IPFS node by clicking the <1>Add to IPFS</1> button above.</0>",
   "companionInfo": "<0>As you are using <1>IPFS Companion</1>, the files view is limited to files added while using the extension.</0>"

--- a/src/bundles/files.js
+++ b/src/bundles/files.js
@@ -70,23 +70,14 @@ const fetchFiles = make(actions.FETCH, async (ipfs, id, { store }) => {
   const stats = await ipfs.files.stat(path)
 
   if (stats.type === 'file') {
-    stats.name = path
-
     return {
       path: path,
       fetched: Date.now(),
       type: 'file',
-      stats: stats,
       read: () => ipfs.files.read(path),
-      // TODO - This will be refactored in the future
-      // I'm adding this here to make the file actions work in preview mode
-      extra: [{
-        name: path.split('/').pop(),
-        path: path,
-        type: 'file',
-        size: stats.size,
-        hash: stats.hash
-      }]
+      name: path.split('/').pop(),
+      size: stats.size,
+      hash: stats.hash
     }
   }
 

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -251,12 +251,12 @@ class FilesPage extends React.Component {
                     <ContextMenu
                       handleClick={this.handleContextMenuClick}
                       isOpen={this.state.isContextMenuOpen}
-                      onShare={() => this.showShareModal(files.extra)}
-                      onDelete={() => this.showDeleteModal(files.extra)}
-                      onRename={() => this.showRenameModal(files.extra)}
-                      onInspect={() => this.inspect(files.extra)}
-                      onDownload={() => this.download(files.extra)}
-                      hash={files.stats.hash} />
+                      onShare={() => this.showShareModal([files])}
+                      onDelete={() => this.showDeleteModal([files])}
+                      onRename={() => this.showRenameModal([files])}
+                      onInspect={() => this.inspect([files])}
+                      onDownload={() => this.download([files])}
+                      hash={files.hash} />
                   </div>
                 )}
             </div>

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -7,7 +7,9 @@ import ComponentLoader from '../../loader/ComponentLoader.js'
 
 class FilesPreview extends React.Component {
   static propTypes = {
-    stats: PropTypes.object.isRequired,
+    hash: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    size: PropTypes.number.isRequired,
     gatewayUrl: PropTypes.string.isRequired,
     read: PropTypes.func.isRequired,
     content: PropTypes.object,
@@ -25,10 +27,10 @@ class FilesPreview extends React.Component {
   }
 
   render () {
-    const { t, stats, gatewayUrl } = this.props
+    const { t, name, size, hash, gatewayUrl } = this.props
 
-    const type = typeFromExt(stats.name)
-    const src = `${gatewayUrl}/ipfs/${stats.hash}`
+    const type = typeFromExt(name)
+    const src = `${gatewayUrl}/ipfs/${hash}`
     const className = 'mw-100 mt3 bg-snow-muted pa2 br2'
 
     switch (type) {
@@ -52,7 +54,7 @@ class FilesPreview extends React.Component {
           </video>
         )
       case 'image':
-        return <img className={className} alt={stats.name} src={src} />
+        return <img className={className} alt={name} src={src} />
       default:
         const cantPreview = (
           <div className='mt4'>
@@ -65,7 +67,7 @@ class FilesPreview extends React.Component {
           </div>
         )
 
-        if (stats.size > 1024 * 1024 * 4) {
+        if (size > 1024 * 1024 * 4) {
           return cantPreview
         }
 


### PR DESCRIPTION
Removes the "pending" TODO on files bundle, by adding three properties to the main object and using it instead.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>