### PR TITLE
chore: use original datatransfer-files-promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,11 +1143,6 @@
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==",
       "dev": true
     },
-    "@hacdias/datatransfer-files-promise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hacdias/datatransfer-files-promise/-/datatransfer-files-promise-1.2.0.tgz",
-      "integrity": "sha512-QwP+AvraAbr69PSq6EzAV2oF8DyvLhFcchY9NQO0LKQkbSRpxNz1bpL0yttgDJCqX74r6+ms+va8rEPCgG+ZrQ=="
-    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -7785,6 +7780,11 @@
           }
         }
       }
+    },
+    "datatransfer-files-promise": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/datatransfer-files-promise/-/datatransfer-files-promise-1.2.3.tgz",
+      "integrity": "sha512-TalUv33xlAXZ4Bq/+CrrzZ2+7KxjPFX8SKXJxhPOPlvD2I9NS05j+XQLoNYNihSvuKdTj+weOfeCGhRcfc9fzw=="
     },
     "date-now": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cids": "^0.6.0",
     "countly-sdk-web": "^19.2.1",
     "d3": "^5.7.0",
-    "@hacdias/datatransfer-files-promise": "^1.2.0",
+    "datatransfer-files-promise": "^1.2.3",
     "details-polyfill": "^1.1.0",
     "file-extension": "^4.0.5",
     "filesize": "^3.6.1",

--- a/src/lib/dnd-backend.js
+++ b/src/lib/dnd-backend.js
@@ -1,4 +1,4 @@
-import { getFilesFromDataTransferItems } from '@hacdias/datatransfer-files-promise'
+import { getFilesFromDataTransferItems } from 'datatransfer-files-promise'
 import HTML5Backend from 'react-dnd-html5-backend'
 
 // If you drop a dir "foo" which contains "cat.jpg" & "dog.png" we receive a


### PR DESCRIPTION
The PR to the original `datatransfer-files-promise` was merged (https://github.com/grabantot/datatransfer-files-promise/pull/3), so this reverts to the original package.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>