### PR TITLE
feat: experiments API for IPFS Desktop

### DIFF
--- a/src/bundles/ipfs-desktop.js
+++ b/src/bundles/ipfs-desktop.js
@@ -21,6 +21,8 @@ if (window.ipfsDesktop) {
 
     selectDesktopSettings: state => state.ipfsDesktop,
 
+    selectDesktopExperiments: () => window.ipfsDesktop.experiments,
+
     doDesktopStartListening: () => async ({ dispatch }) => {
       window.ipfsDesktop.onConfigChanged(config => {
         dispatch({

--- a/src/bundles/ipfs-desktop.js
+++ b/src/bundles/ipfs-desktop.js
@@ -7,6 +7,7 @@ let bundle = {
 if (window.ipfsDesktop) {
   bundle = {
     ...bundle,
+
     reducer: (state = {}, action) => {
       if (!action.type.startsWith('DESKTOP_')) {
         return state
@@ -21,7 +22,9 @@ if (window.ipfsDesktop) {
 
     selectDesktopSettings: state => state.ipfsDesktop,
 
-    selectDesktopExperiments: () => window.ipfsDesktop.experiments,
+    selectDesktopAvailableExperiments: () => window.ipfsDesktop.experiments,
+
+    selectDesktopExperiments: state => state.ipfsDesktop.experiments,
 
     doDesktopStartListening: () => async ({ dispatch }) => {
       window.ipfsDesktop.onConfigChanged(config => {
@@ -34,6 +37,10 @@ if (window.ipfsDesktop) {
 
     doDesktopSettingsToggle: (setting) => () => {
       window.ipfsDesktop.toggleSetting(setting)
+    },
+
+    doDesktopToggleExperiment: (id) => () => {
+      window.ipfsDesktop.toggleSetting(`experiment.${id}`)
     },
 
     init: store => {


### PR DESCRIPTION
@cwaring this adds an experiments API for IPFS Desktop redux bundle so we can get the current enabled state, know if an experiment is available and toggle it. The API is:

**To know if `expId` is available:**

```js
store.selectDesktopAvailableExperiments().includes('expId')
```

**To know if `expId` is enabled:**

```js
store.selectDesktopExperiments().expId
```

**To toggle `expId`:**

```js
store. doDesktopToggleExperiment('expId')
```

This should only be used for IPFS Desktop-related experiments such as NPM on IPFS.