### PR TITLE
feat: add ipfs config help link

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -98,5 +98,6 @@
     }
   },
   "ipfsCmdTools": "IPFS command line tools",
-  "ipfsCmdToolsDescription": "Add <0>ipfs</0> binary to your system <0>PATH</0> so you can use it in the command line."
+  "ipfsCmdToolsDescription": "Add <0>ipfs</0> binary to your system <0>PATH</0> so you can use it in the command line.",
+  "ipfsConfigHelp": "IPFS Config Help"
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -24,6 +24,7 @@
   "changesSaved": "Your changes have been saved.",
   "settingsWillBeUsedNextTime": "The new settings will be used next time you restart the IPFS daemon.",
   "ipfsConfigDescription": "The IPFS config file is a JSON document. It is read once when the IPFS daemon is started. Save your changes, then restart the IPFS daemon to apply them.",
+  "ipfsConfigHelp": "Check the documentation for further information.",
   "ipfsDesktop": "IPFS Desktop",
   "takeScreenshot": "Take screenshot",
   "takeScreenshotDescription": "Use <0>{key1}</0> + <2>{key2}</2> + <3>{key3}</3> to take screenshots and add them to your repository.",
@@ -98,6 +99,5 @@
     }
   },
   "ipfsCmdTools": "IPFS command line tools",
-  "ipfsCmdToolsDescription": "Add <0>ipfs</0> binary to your system <0>PATH</0> so you can use it in the command line.",
-  "ipfsConfigHelp": "IPFS Config Help"
+  "ipfsCmdToolsDescription": "Add <0>ipfs</0> binary to your system <0>PATH</0> so you can use it in the command line."
 }

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -171,7 +171,7 @@ const SettingsInfo = ({ t, isIpfsConnected, isConfigBlocked, hasExternalChanges,
   }
   return (
     <p className='ma0 mr2 lh-copy charcoal f6'>
-      {t('ipfsConfigDescription')} <a href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md' rel='noopener noreferrer' target='_blank' className='link'>{t('ipfsConfigHelp')}</a>
+      {t('ipfsConfigDescription')} <a href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md' rel='noopener noreferrer' target='_blank' className='link blue'>{t('ipfsConfigHelp')}</a>
     </p>
   )
 }

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -84,6 +84,18 @@ export const SettingsPage = ({
               hasExternalChanges={hasExternalChanges}
               isSaving={isSaving}
               onClick={onSave} />
+            <a href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md'
+              rel='noopener noreferrer'
+              title={t('ipfsConfigHelp')}
+              target='_blank'>
+              <Button
+                minWidth={20}
+                height={40}
+                className='mt2 mt0-l ml2-l'
+                bg='bg-blue' >
+                ?
+              </Button>
+            </a>
           </div>
         ) : null }
       </div>

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -84,18 +84,6 @@ export const SettingsPage = ({
               hasExternalChanges={hasExternalChanges}
               isSaving={isSaving}
               onClick={onSave} />
-            <a href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md'
-              rel='noopener noreferrer'
-              title={t('ipfsConfigHelp')}
-              target='_blank'>
-              <Button
-                minWidth={20}
-                height={40}
-                className='mt2 mt0-l ml2-l'
-                bg='bg-blue' >
-                ?
-              </Button>
-            </a>
           </div>
         ) : null }
       </div>
@@ -183,7 +171,7 @@ const SettingsInfo = ({ t, isIpfsConnected, isConfigBlocked, hasExternalChanges,
   }
   return (
     <p className='ma0 mr2 lh-copy charcoal f6'>
-      {t('ipfsConfigDescription')}
+      {t('ipfsConfigDescription')} <a href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md' rel='noopener noreferrer' target='_blank' className='link'>{t('ipfsConfigHelp')}</a>
     </p>
   )
 }


### PR DESCRIPTION
Closes #1110. The button also has a hovering title saying 'IPFS Config Help'.

<img width="1094" alt="Screenshot 2019-08-16 at 09 18 20" src="https://user-images.githubusercontent.com/5447088/63153671-d0fba400-c006-11e9-9388-09b5db05d6b6.png">
<img width="1094" alt="Screenshot 2019-08-16 at 09 18 10" src="https://user-images.githubusercontent.com/5447088/63153673-d0fba400-c006-11e9-96bf-59735cecdb16.png">

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>

/cc @autonome

@autonome I can't set you as a reviewer... probably we need to give you permission somewhere. @olizilla do you know anything about this?