### PR TITLE
feat: add inspect near browse

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -101,7 +101,7 @@
     }
   },
   "exploreForm": {
-    "explore": "Explore",
+    "browse": "Browse",
     "inspect": "Inspect"
   },
   "hashUnavailable": "hash unavailable",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -101,7 +101,8 @@
     }
   },
   "exploreForm": {
-    "explore": "Explore"
+    "explore": "Explore",
+    "inspect": "Inspect"
   },
   "hashUnavailable": "hash unavailable",
   "pins": "Pins",

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -65,9 +65,9 @@
       "paragraph1": "This chart shows the network bandwith usage over time.",
       "paragraph2": "The speedometers show the current outgoing and incoming traffic."
     },
-    "step5": {
+    "stepExplore": {
       "title": "Explore",
-      "paragraph1": "Paste a CID and explore how that data is structured and linked across protocols."
+      "paragraph": "Paste a CID and explore the files contained behind the CID or see how that data is structured and linked across protocols."
     }
   },
   "bandwidthStats": "Bandwidth stats",

--- a/src/App.js
+++ b/src/App.js
@@ -58,7 +58,7 @@ export class App extends Component {
   }
 
   render () {
-    const { t, route: Page, ipfsReady, doFilesNavigateTo, routeInfo: { url }, navbarIsOpen, connectDropTarget, canDrop, isOver, showTooltip } = this.props
+    const { t, route: Page, ipfsReady, doFilesNavigateTo, doExploreUserProvidedPath, routeInfo: { url }, navbarIsOpen, connectDropTarget, canDrop, isOver, showTooltip } = this.props
 
     return connectDropTarget(
       <div className='sans-serif h-100' onClick={getNavHelper(this.props.doUpdateUrl)}>
@@ -71,7 +71,7 @@ export class App extends Component {
           <div className='flex-auto-l'>
             <div className='flex items-center ph3 ph4-l' style={{ height: 75, background: '#F0F6FA', paddingTop: '20px', paddingBottom: '15px' }}>
               <div className='joyride-app-explore' style={{ width: 560 }}>
-                <FilesExploreForm onNavigate={doFilesNavigateTo} />
+                <FilesExploreForm onBrowse={doFilesNavigateTo} onInspect={doExploreUserProvidedPath} />
               </div>
               <div className='dn flex-ns flex-auto items-center justify-end'>
                 <TourHelper />
@@ -128,6 +128,7 @@ export default connect(
   'selectIpfsReady',
   'selectShowTooltip',
   'doFilesNavigateTo',
+  'doExploreUserProvidedPath',
   'doUpdateUrl',
   'doUpdateHash',
   'doInitIpfs',

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -238,8 +238,9 @@ export default () => ({
   doFilesNavigateTo: (path) => async ({ store }) => {
     const link = path.split('/').map(p => encodeURIComponent(p)).join('/')
     const files = store.selectFiles()
+    const url = store.selectFilesPathInfo()
 
-    if (files && files.path === link) {
+    if (files && files.path === link && url) {
       store.doFilesFetch()
     } else {
       store.doUpdateHash(`${link}`)

--- a/src/files/explore-form/FilesExploreForm.css
+++ b/src/files/explore-form/FilesExploreForm.css
@@ -1,0 +1,9 @@
+.ExploreFormButton,
+.ExploreFormButton:hover + .ExploreFormButton  {
+  max-width: 3.3em
+}
+
+.ExploreFormButton:last-of-type,
+.ExploreFormButton:hover {
+  max-width: 200px;
+}

--- a/src/files/explore-form/FilesExploreForm.js
+++ b/src/files/explore-form/FilesExploreForm.js
@@ -96,10 +96,10 @@ class FilesExploreForm extends React.Component {
             minWidth={0}
             disabled={!this.isValid}
             style={{ borderRadius: '0' }}
-            title={t('exploreForm.explore')}
+            title={t('exploreForm.browse')}
             className='ExploreFormButton button-reset pv1 ph2 ba f7 fw4 white bg-aqua overflow-hidden' >
             <StrokeFolder style={{ height: 24 }} className='dib fill-current-color v-mid' />
-            <span className='ml2'>{t('exploreForm.explore')}</span>
+            <span className='ml2'>{t('exploreForm.browse')}</span>
           </Button>
         </div>
       </form>

--- a/src/files/explore-form/FilesExploreForm.js
+++ b/src/files/explore-form/FilesExploreForm.js
@@ -2,30 +2,43 @@ import React from 'react'
 import isIPFS from 'is-ipfs'
 import PropTypes from 'prop-types'
 import { withTranslation } from 'react-i18next'
-import StrokeIpld from '../../icons/StrokeFolder'
+import StrokeFolder from '../../icons/StrokeFolder'
+import StrokeIpld from '../../icons/StrokeIpld'
 import Button from '../../components/button/Button'
+import './FilesExploreForm.css'
 
 class FilesExploreForm extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      path: ''
+      path: '',
+      hideExplore: false
     }
     this.onChange = this.onChange.bind(this)
     this.onSubmit = this.onSubmit.bind(this)
+    this.onInspect = this.onInspect.bind(this)
   }
 
   onSubmit (evt) {
     evt.preventDefault()
 
-    if (this.canBrowse) {
+    if (this.isValid) {
       let path = this.path
 
       if (isIPFS.cid(path)) {
         path = `/ipfs/${path}`
       }
 
-      this.props.onNavigate(path)
+      this.props.onBrowse(path)
+      this.setState({ path: '' })
+    }
+  }
+
+  onInspect (evt) {
+    evt.preventDefault()
+
+    if (this.isValid) {
+      this.props.onInspect(this.path)
       this.setState({ path: '' })
     }
   }
@@ -40,7 +53,7 @@ class FilesExploreForm extends React.Component {
   }
 
   get isValid () {
-    return isIPFS.cid(this.path) || isIPFS.path(this.path)
+    return this.path !== '' && (isIPFS.cid(this.path) || isIPFS.path(this.path))
   }
 
   get inputClass () {
@@ -55,10 +68,6 @@ class FilesExploreForm extends React.Component {
     }
   }
 
-  get canBrowse () {
-    return this.path !== '' && this.isValid
-  }
-
   render () {
     const { t } = this.props
     return (
@@ -69,13 +78,27 @@ class FilesExploreForm extends React.Component {
             <small id='ipfs-path-desc' className='o-0 absolute f6 black-60 db mb2'>Paste in a CID or IPFS path</small>
           </div>
         </div>
-        <div className='flex-none'>
+        <div className='flex flex-row-reverse mb2'>
           <Button
             type='submit'
-            disabled={!this.canBrowse}
+            minWidth={0}
+            disabled={!this.isValid}
+            title={t('exploreForm.inspect')}
             style={{ borderRadius: '0 3px 3px 0' }}
-            className='button-reset pv1 pl2 pr3 ba f7 fw4 white bg-aqua' >
+            onClick={this.onInspect}
+            bg='bg-teal'
+            className='ExploreFormButton button-reset pv1 ph2 ba f7 fw4 white overflow-hidden' >
             <StrokeIpld style={{ height: 24 }} className='dib fill-current-color v-mid' />
+            <span className='ml2'>{t('exploreForm.inspect')}</span>
+          </Button>
+          <Button
+            type='submit'
+            minWidth={0}
+            disabled={!this.isValid}
+            style={{ borderRadius: '0' }}
+            title={t('exploreForm.explore')}
+            className='ExploreFormButton button-reset pv1 ph2 ba f7 fw4 white bg-aqua overflow-hidden' >
+            <StrokeFolder style={{ height: 24 }} className='dib fill-current-color v-mid' />
             <span className='ml2'>{t('exploreForm.explore')}</span>
           </Button>
         </div>
@@ -86,7 +109,8 @@ class FilesExploreForm extends React.Component {
 
 FilesExploreForm.propTypes = {
   t: PropTypes.func.isRequired,
-  onNavigate: PropTypes.func.isRequired
+  onInspect: PropTypes.func.isRequired,
+  onBrowse: PropTypes.func.isRequired
 }
 
 export default withTranslation('files')(FilesExploreForm)

--- a/src/files/explore-form/FilesExploreForm.stories.js
+++ b/src/files/explore-form/FilesExploreForm.stories.js
@@ -10,6 +10,6 @@ storiesOf('Files', module)
   .addDecorator(i18n)
   .add('Explore Form', () => (
     <div className='ma3 pa3 bg-snow-muted mw6'>
-      <FilesExploreForm onNavigate={action('Navigate')} />
+      <FilesExploreForm onBrowse={action('Browse')} onInspect={action('Inspect')} />
     </div>
   ))

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -64,8 +64,8 @@ export const statusTour = {
     },
     {
       content: <div className='montserrat charcoal'>
-        <h2 className='f3 fw4'>{t('tour.step5.title')}</h2>
-        <p className='tl f6'>{t('tour.step5.paragraph1')}</p>
+        <h2 className='f3 fw4'>{t('tour.stepExplore.title')}</h2>
+        <p className='tl f6'>{t('tour.stepExplore.paragraph')}</p>
       </div>,
       locale: { last: 'Finish' },
       placement: 'right',


### PR DESCRIPTION
Close #1109. Closes #1112. #1027 introduced a regression: we replaced the IPLD explore bar by the files Explore bar. Although, we didn't put the IPLD explore bar anywhere else.

This PR makes the top bar work for both Files and IPLD sections. How? Like this:

![Untitled](https://user-images.githubusercontent.com/5447088/63161232-79196900-c017-11e9-8e60-36c34fe89c69.gif)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>