### PR TITLE
fix: non unixfs on files

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -108,5 +108,6 @@
   "pinned": "Pinned",
   "blocks": "Blocks",
   "more": "More",
-  "files": "Files"
+  "files": "Files",
+  "cidNotFileNorDir": "The current link isn't a file, nor a directory. Try to <0>fuck</0> it instead."
 }

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -109,5 +109,5 @@
   "blocks": "Blocks",
   "more": "More",
   "files": "Files",
-  "cidNotFileNorDir": "The current link isn't a file, nor a directory. Try to <0>fuck</0> it instead."
+  "cidNotFileNorDir": "The current link isn't a file, nor a directory. Try to <0>inspect</0> it instead."
 }

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -67,7 +67,18 @@ const fetchFiles = make(ACTIONS.FETCH, async (ipfs, id, { store }) => {
     realPath = await ipfs.name.resolve(realPath)
   }
 
-  const stats = await ipfs.files.stat(realPath)
+  let stats
+
+  try {
+    stats = await ipfs.files.stat(realPath)
+  } catch (e) {
+    if (e.toString().toLowerCase().includes('unixfs')) {
+      return {
+        path: path,
+        type: 'unknown'
+      }
+    }
+  }
 
   if (stats.type === 'file') {
     return {

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -134,13 +134,23 @@ class FilesPage extends React.Component {
   }
 
   get mainView () {
-    const { files } = this.props
+    const { files, doExploreUserProvidedPath } = this.props
 
     if (!files) {
       return (<div></div>)
     }
 
-    if (files.type !== 'directory') {
+    if (files.type === 'unknown') {
+      return (
+        <div>
+          <Trans i18nKey='cidNotFileNorDir'>
+            The current link isn't a file, nor a directory. Try to <span className='link blue pointer' onClick={() => doExploreUserProvidedPath(files.path)}>inspect</span> it instead.
+          </Trans>
+        </div>
+      )
+    }
+
+    if (files.type === 'file') {
       return (
         <FilePreview {...files} />
       )
@@ -295,5 +305,6 @@ export default connect(
   'selectToursEnabled',
   'doFilesWrite',
   'doFilesDownloadLink',
+  'doExploreUserProvidedPath',
   withTour(withTranslation('files')(FilesPage))
 )

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -141,10 +141,14 @@ class FilesPage extends React.Component {
     }
 
     if (files.type === 'unknown') {
+      const path = files.path.startsWith('/pins') ?
+        files.path.slice(6) :
+        files.path
+
       return (
         <div>
           <Trans i18nKey='cidNotFileNorDir'>
-            The current link isn't a file, nor a directory. Try to <span className='link blue pointer' onClick={() => doExploreUserProvidedPath(files.path)}>inspect</span> it instead.
+            The current link isn't a file, nor a directory. Try to <span className='link blue pointer' onClick={() => doExploreUserProvidedPath(path)}>inspect</span> it instead.
           </Trans>
         </div>
       )
@@ -212,6 +216,7 @@ class FilesPage extends React.Component {
           handleClick={this.handleContextMenu}
           isUpperDir={contextMenu.file && contextMenu.file.name === '..'}
           isMfs={filesPathInfo ? filesPathInfo.isMfs : false}
+          isUnknown={contextMenu.file && contextMenu.file.type === 'unknown'}
           pinned={contextMenu.file && contextMenu.file.pinned}
           showDots={false}
           hash={contextMenu.file && contextMenu.file.hash}

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -141,9 +141,9 @@ class FilesPage extends React.Component {
     }
 
     if (files.type === 'unknown') {
-      const path = files.path.startsWith('/pins') ?
-        files.path.slice(6) :
-        files.path
+      const path = files.path.startsWith('/pins')
+        ? files.path.slice(6)
+        : files.path
 
       return (
         <div>

--- a/src/files/context-menu/ContextMenu.js
+++ b/src/files/context-menu/ContextMenu.js
@@ -26,7 +26,7 @@ class ContextMenu extends React.Component {
     const {
       t, onRename, onDelete, onDownload, onInspect, onShare,
       translateX, translateY, className, showDots,
-      isUpperDir, isMfs, pinned
+      isUpperDir, isMfs, isUnknown, pinned
     } = this.props
 
     return (
@@ -40,19 +40,19 @@ class ContextMenu extends React.Component {
           translateY={-translateY}
           open={this.props.isOpen}
           onDismiss={this.props.handleClick}>
-          { !isUpperDir && isMfs && onDelete &&
+          { !isUpperDir && !isUnknown && isMfs && onDelete &&
             <Option onClick={this.wrap('onDelete')}>
               <StrokeTrash className='w2 mr2 fill-aqua' />
               {t('actions.delete')}
             </Option>
           }
-          { !isUpperDir && isMfs && onRename &&
+          { !isUpperDir && !isUnknown && isMfs && onRename &&
             <Option onClick={this.wrap('onRename')}>
               <StrokePencil className='w2 mr2 fill-aqua' />
               {t('actions.rename')}
             </Option>
           }
-          { !isUpperDir && onDownload &&
+          { !isUpperDir && !isUnknown && onDownload &&
             <Option onClick={this.wrap('onDownload')}>
               <StrokeDownload className='w2 mr2 fill-aqua' />
               {t('actions.download')}
@@ -89,6 +89,7 @@ class ContextMenu extends React.Component {
 ContextMenu.propTypes = {
   isMfs: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
+  isUnknown: PropTypes.bool.isRequired,
   hash: PropTypes.string,
   isUpperDir: PropTypes.bool,
   pinned: PropTypes.bool,
@@ -111,6 +112,7 @@ ContextMenu.defaultProps = {
   isMfs: false,
   isOpen: false,
   isUpperDir: false,
+  isUnknown: false,
   top: 0,
   left: 0,
   right: 'auto',

--- a/src/files/file-icon/FileIcon.js
+++ b/src/files/file-icon/FileIcon.js
@@ -8,12 +8,17 @@ import DocCalc from '../../icons/GlyphDocCalc'
 import DocMusic from '../../icons/GlyphDocMusic'
 import DocPicture from '../../icons/GlyphDocPicture'
 import DocText from '../../icons/GlyphDocText'
+import Cube from '../../icons/StrokeCube'
 
 const style = { width: 36 }
 
 export default function FileIcon ({ name, type, cls = '' }) {
   if (type === 'directory') {
     return <Folder className={`fill-aqua ${cls}`} style={style} />
+  }
+
+  if (type === 'unknown') {
+    return <Cube className={`fill-aqua ${cls}`} style={style} />
   }
 
   switch (typeFromExt(name)) {

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -305,7 +305,7 @@ export class FilesList extends React.Component {
   }
 
   rowRenderer = ({ index, key, style }) => {
-    const { files, pins, upperDir, filesPathInfo, isOver, canDrop, onNavigate, onAddFiles } = this.props
+    const { files, pins, upperDir, filesPathInfo, isOver, canDrop, onNavigate, onInspect, onAddFiles } = this.props
     const { selected, focused, isDragging } = this.state
 
     if (upperDir) {
@@ -342,7 +342,13 @@ export class FilesList extends React.Component {
           isMfs={filesPathInfo.isMfs}
           name={files[index].name}
           onSelect={this.toggleOne}
-          onNavigate={() => onNavigate(files[index].path)}
+          onNavigate={() => {
+            if (files[index].type === 'unknown') {
+              onInspect(files[index].hash)
+            } else {
+              onNavigate(files[index].path)
+            }
+          }}
           onAddFiles={onAddFiles}
           onMove={this.move}
           focused={focused === files[index].name}

--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -74,7 +74,7 @@ class Header extends React.Component {
                     fill='fill-aqua'
                     className='f6 relative flex justify-center items-center'
                     minWidth='100px'
-                    disabled={!files || filesPathInfo.isRoot}
+                    disabled={!files || filesPathInfo.isRoot || files.type === 'unknown'}
                     onClick={this.handleContextMenu}>
                     <GlyphDots className='w1 mr2' />
                     { t('more') }


### PR DESCRIPTION
Closes #1095.

Clicking on the item goes to to the explore section:

![image](https://user-images.githubusercontent.com/5447088/63171689-04a0f300-c034-11e9-8ed3-0525cff8ac9c.png)

It has less ctx menu opts:

![image](https://user-images.githubusercontent.com/5447088/63171709-12ef0f00-c034-11e9-8a8b-c98671efc545.png)

If the user tries to navigate to it anyway (though the URL or sth):

![image](https://user-images.githubusercontent.com/5447088/63171736-226e5800-c034-11e9-8f0d-6e5a07723cf6.png)
