### PR TITLE
chore: Peer page sorting adjustments

### DIFF
--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -152,8 +152,7 @@ export default function (opts) {
           locationObj.latitude
         ]
         const connection = parseConnection(peer.addr)
-        const rawLatency = parseLatency(peer.latency)
-        const latency = rawLatency ? `${rawLatency}ms` : null
+        const latency = parseLatency(peer.latency)
         const notes = parseNotes(peer, bootstrapPeers)
 
         return {
@@ -163,7 +162,6 @@ export default function (opts) {
           coordinates,
           connection,
           latency,
-          rawLatency,
           notes
         }
       })
@@ -251,7 +249,7 @@ const isNonHomeIPv4 = t => t[0] === 4 && t[1] !== '127.0.0.1'
 const toLocationString = loc => {
   if (!loc) return null
   const { country_name: country, city } = loc
-  return city && country ? `${city}, ${country}` : country
+  return city && country ? `${country}, ${city}` : country
 }
 
 const parseConnection = (multiaddr) => {

--- a/src/bundles/peers.js
+++ b/src/bundles/peers.js
@@ -4,12 +4,7 @@ import ms from 'milliseconds'
 const bundle = createAsyncResourceBundle({
   name: 'peers',
   actionBaseType: 'PEERS',
-  getPromise: ({ getIpfs }) => getIpfs().swarm.peers({ verbose: true })
-    .then((peers) => peers.sort((a, b) => {
-      const aAddr = a.addr.toString()
-      const bAddr = b.addr.toString()
-      return aAddr.localeCompare(bAddr, undefined, { numeric: true, sensitivity: 'base' })
-    })),
+  getPromise: ({ getIpfs }) => getIpfs().swarm.peers({ verbose: true }),
   staleAfter: ms.seconds(10),
   persist: false,
   checkIfOnline: false

--- a/src/peers/PeersTable/PeersTable.js
+++ b/src/peers/PeersTable/PeersTable.js
@@ -49,7 +49,7 @@ export class PeersTable extends React.Component {
     const style = { width: '60px' }
 
     return cellData
-      ? <span className='dib tr' style={style}>{cellData}</span>
+      ? <span className='dib tr' style={style}>{cellData}ms</span>
       : <span className='dib tr o-40' style={style}>-</span>
   }
 
@@ -83,7 +83,7 @@ export class PeersTable extends React.Component {
     const { className, peerLocationsForSwarm, t } = this.props
     const { sortBy, sortDirection } = this.state
 
-    const sortedList = (peerLocationsForSwarm || []).sort(sortByProperty(sortBy === 'latency' ? 'rawLatency' : sortBy, sortDirection === SortDirection.ASC ? 1 : -1))
+    const sortedList = (peerLocationsForSwarm || []).sort(sortByProperty(sortBy, sortDirection === SortDirection.ASC ? 1 : -1))
     const tableHeight = 400
 
     return (
@@ -103,11 +103,11 @@ export class PeersTable extends React.Component {
               sort={this.sort}
               sortBy={sortBy}
               sortDirection={sortDirection}>
-              <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='locationCode' width={450} className='f6 navy-muted truncate pl2' />
+              <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={450} className='f6 navy-muted truncate pl2' />
               <Column label={t('latency')} cellRenderer={this.latencyCellRenderer} dataKey='latency' width={250} className='f6 navy-muted monospace pl2' />
               <Column label={t('peerId')} cellRenderer={this.peerIdCellRenderer} dataKey='peerId' width={250} className='charcoal monospace truncate f7 pl2' />
               <Column label={t('connection')} dataKey='connection' width={400} className='f6 navy-muted truncate pl2' />
-              <Column label={t('notes')} cellRenderer={this.notesCellRenderer} dataKey='notes' width={400} className='charcoal monospace truncate f7 pl2' />
+              <Column label={t('notes')} cellRenderer={this.notesCellRenderer} disableSort dataKey='notes' width={400} className='charcoal monospace truncate f7 pl2' />
             </Table>
           )}
         </AutoSizer> }


### PR DESCRIPTION
In response to #1072 I've done the following:
- [x] Removed sorting by multiaddr
- [x] Fixed location sorting

I also made the following minor changes:
- Remove sorting notes column
- Simplified latency sorting (removed `rawLatency`)

---

The last item mentioned in #1072 is checking performance with a large number of peers. Any suggestions about the best way to test that?