### PR TITLE
fix: stop crashing pin screen on a single ipfs.files.stat error

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -31,14 +31,14 @@ const stat = async (ipfs, hashOrPath) => {
     const stats = await ipfs.files.stat(path)
     return stats
   } catch (e) {
-    if (e.toString().toLowerCase().includes('unixfs')) {
-      return {
-        path: hashOrPath,
-        hash: hashOrPath,
-        type: 'unknown'
-      }
-    } else {
-      throw e
+    // Discard error and mark DAG as 'unknown' to unblock listing other pins.
+    // Clicking on 'unknown' entry will open it in Inspector.
+    // No information is lost: if there is an error related
+    // to specified hashOrPath user will read it in Inspector.
+    return {
+      path: hashOrPath,
+      hash: hashOrPath,
+      type: 'unknown'
     }
   }
 }


### PR DESCRIPTION
This PR makes pin listing more robust by never throwing errors returned by
`ipfs.files.stat` for individual pins. Fixes https://github.com/ipfs-shipyard/ipfs-webui/issues/1095 for all repos.

### Motivation

Error handling introduced in #1115 was bit naive and when anything other than 'non unixfs' error was detected, it was re-thrown. This broke rendering of pin list on my end:

> ![](https://user-images.githubusercontent.com/157609/62941627-ce1a6c80-bdd6-11e9-9976-3f2f7425dbc3.png)

My repo has some bizzare DAGs, which provided good sandbox for testing shortcomings of old error handling:

> ![unhandled-errors-2019-08-20--16-32-16](https://user-images.githubusercontent.com/157609/63359843-b78f8a80-c36d-11e9-8854-7d588e13d318.png)

### Changes

We just mark non-unixfs or errored items as 'unknown' and continue.
That way user is able to list all pins, and if they click on an 'unknown' item that produces an error, it will be displayed in IPLD Explorer (Inspector), so no information is lost.