### PR TITLE
feat: improve nav bar

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -271,5 +271,10 @@ export default () => ({
 
   doFilesUpdateSorting: (by, asc) => async ({ dispatch }) => {
     dispatch({ type: 'FILES_UPDATE_SORT', payload: { by, asc } })
-  }
+  },
+
+  doFilesSizeGet: make(ACTIONS.FILES_SIZE_GET, async (ipfs) => {
+    const stat = await ipfs.files.stat('/')
+    return { size: stat.cumulativeSize }
+  })
 })

--- a/src/bundles/files/consts.js
+++ b/src/bundles/files/consts.js
@@ -11,7 +11,8 @@ export const ACTIONS = {
   ADD_BY_PATH: 'ADDBYPATH',
   PIN_ADD: 'PIN_ADD',
   PIN_REMOVE: 'PIN_REMOVE',
-  PIN_LIST: 'PIN_LIST'
+  PIN_LIST: 'PIN_LIST',
+  FILES_SIZE_GET: 'FILES_SIZE_GET'
 }
 
 export const SORTING = {

--- a/src/bundles/files/index.js
+++ b/src/bundles/files/index.js
@@ -96,6 +96,12 @@ export default () => {
         const action = state.pending.find(a => a.id === id)
         let additional
 
+        if (type === ACTIONS.FILES_SIZE_GET) {
+          additional = {
+            mfsSize: data.size
+          }
+        }
+
         if (type === ACTIONS.FETCH) {
           additional = {
             pageContent: data

--- a/src/bundles/files/selectors.js
+++ b/src/bundles/files/selectors.js
@@ -7,6 +7,8 @@ export default () => ({
 
   selectPins: (state) => state.files.pins,
 
+  selectFilesSize: (state) => state.files.mfsSize,
+
   selectFilesIsFetching: (state) => state.files.pending.some(a => a.type === ACTIONS.FETCH),
 
   selectShowLoadingAnimation: (state) => {

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -44,6 +44,7 @@ class FilesPage extends React.Component {
   componentDidMount () {
     this.props.doFilesFetch()
     this.props.doPinsFetch()
+    this.props.doFilesSizeGet()
   }
 
   componentDidUpdate (prev) {
@@ -314,5 +315,6 @@ export default connect(
   'doFilesWrite',
   'doFilesDownloadLink',
   'doExploreUserProvidedPath',
+  'doFilesSizeGet',
   withTour(withTranslation('files')(FilesPage))
 )

--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -24,7 +24,11 @@ function BarOption ({ children, title, isLink = false, className = '', ...etc })
 }
 
 function humanSize (size) {
-  return filesize(size || 0, { round: 1, spacer: '' })
+  if (!size) return 'N/A'
+
+  return filesize(size || 0, {
+    round: size >= 1000000000 ? 1 : 0, spacer: ''
+  })
 }
 
 class Header extends React.Component {
@@ -55,7 +59,7 @@ class Header extends React.Component {
 
         <div className='mb3 flex justify-between items-center bg-snow-muted joyride-files-add'>
           <BarOption title={t('files')} isLink onClick={() => { onNavigate('/files') }}>
-            { filesSize ? humanSize(filesSize || 0) : 'N/A' }
+            { humanSize(filesSize) }
           </BarOption>
 
           <BarOption title={t('pins')} isLink onClick={() => { onNavigate('/pins') }}>
@@ -67,7 +71,7 @@ class Header extends React.Component {
           </BarOption>
 
           <BarOption title={t('repo')}>
-            { repoSize ? humanSize(repoSize || 0) : 'N/A' }
+            { humanSize(repoSize) }
           </BarOption>
 
           <div className='pa3'>

--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import filesize from 'filesize'
 import SimplifyNumber from 'simplify-number'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
@@ -8,17 +9,16 @@ import FileInput from '../file-input/FileInput'
 import Button from '../../components/button/Button'
 // Icons
 import GlyphDots from '../../icons/GlyphDots'
-import GlyphHome from '../../icons/GlyphHome'
 
-function BarOption ({ children, title, className = '', ...etc }) {
+function BarOption ({ children, title, isLink = false, className = '', ...etc }) {
   className += ' tc pa3'
 
   if (etc.onClick) className += ' pointer'
 
   return (
     <div className={className} {...etc}>
-      <span className='db f4 navy'>{children}</span>
-      <span className='db ttl gray'>{title}</span>
+      <span className='nowrap db f4 navy'>{children}</span>
+      <span className={`db ttl ${isLink ? 'navy underline' : 'gray'}`}>{title}</span>
     </div>
   )
 }
@@ -37,7 +37,9 @@ class Header extends React.Component {
       files, writeFilesProgress, t,
       pins,
       filesPathInfo,
+      filesSize,
       repoNumObjects,
+      repoSize,
       onNavigate
     } = this.props
 
@@ -48,16 +50,20 @@ class Header extends React.Component {
         </div>
 
         <div className='mb3 flex justify-between items-center bg-snow-muted joyride-files-add'>
+          <BarOption title={t('files')} isLink onClick={() => { onNavigate('/files') }}>
+            { filesSize ? filesize(filesSize || 0, { round: 1 }) : 'N/A' }
+          </BarOption>
+
+          <BarOption title={t('pins')} isLink onClick={() => { onNavigate('/pins') }}>
+            { pins ? SimplifyNumber(pins.length) : '-' }
+          </BarOption>
+
           <BarOption title={t('blocks')}>
             { repoNumObjects ? SimplifyNumber(repoNumObjects, { decimal: 0 }) : 'N/A' }
           </BarOption>
 
-          <BarOption title={t('pins')} onClick={() => { onNavigate('/pins') }}>
-            { pins ? SimplifyNumber(pins.length) : '-' }
-          </BarOption>
-
-          <BarOption title={t('files')} onClick={() => { onNavigate('/files') }}>
-            <GlyphHome viewBox='20 20 60 60' className='w1 h1 fill-navy' />
+          <BarOption title={t('repo')}>
+            { repoSize ? filesize(repoSize || 0, { round: 1 }) : 'N/A' }
           </BarOption>
 
           <div className='pa3'>
@@ -91,6 +97,7 @@ class Header extends React.Component {
 
 export default connect(
   'selectPins',
+  'selectFilesSize',
   'selectRepoSize',
   'selectRepoNumObjects',
   'selectFilesPathInfo',

--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -23,6 +23,10 @@ function BarOption ({ children, title, isLink = false, className = '', ...etc })
   )
 }
 
+function humanSize (size) {
+  return filesize(size || 0, { round: 1, spacer: '' })
+}
+
 class Header extends React.Component {
   handleContextMenu = (ev) => {
     const pos = this.dotsWrapper.getBoundingClientRect()
@@ -51,7 +55,7 @@ class Header extends React.Component {
 
         <div className='mb3 flex justify-between items-center bg-snow-muted joyride-files-add'>
           <BarOption title={t('files')} isLink onClick={() => { onNavigate('/files') }}>
-            { filesSize ? filesize(filesSize || 0, { round: 1 }) : 'N/A' }
+            { filesSize ? humanSize(filesSize || 0) : 'N/A' }
           </BarOption>
 
           <BarOption title={t('pins')} isLink onClick={() => { onNavigate('/pins') }}>
@@ -63,7 +67,7 @@ class Header extends React.Component {
           </BarOption>
 
           <BarOption title={t('repo')}>
-            { repoSize ? filesize(repoSize || 0, { round: 1 }) : 'N/A' }
+            { repoSize ? humanSize(repoSize || 0) : 'N/A' }
           </BarOption>
 
           <div className='pa3'>


### PR DESCRIPTION
This applies #1122!

![image](https://user-images.githubusercontent.com/5447088/63647382-62aa9600-c718-11e9-8cd1-c2d57cae1c52.png)

Is it better with one or zero decimals?

![image](https://user-images.githubusercontent.com/5447088/63681768-5264ea80-c7ee-11e9-889f-b689b4f346a8.png)

I believe that using 0 decimals can hide a bit the difference between repo and the files sizing... 

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>