### PR TITLE
chore: add dev.webui.ipfs.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
       - image: olizilla/ipfs-dns-deploy:latest
         environment:
           DOMAIN: webui.ipfs.io
-          DEV_DOMAIN: dev.webui.ipfs.io
           BUILD_DIR: build
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
 
             if [ "$CIRCLE_BRANCH" == "master" ] ; then
-              dnslink-dnsimple -d $DEV_DOMAIN -r _dnslink -l /ipfs/$hash
+              dnslink-dnsimple -d $DOMAIN -r _dnslink.dev -l /ipfs/$hash
             fi
 
             if [ ! -z "$CIRCLE_TAG" ] ; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
               dnslink-dnsimple -d $DOMAIN -r _dnslink.dev -l /ipfs/$hash
             fi
 
-            if [ ! -z "$CIRCLE_TAG" ] ; then
+            if [ npx semver "$CIRCLE_TAG" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - image: olizilla/ipfs-dns-deploy:latest
         environment:
           DOMAIN: webui.ipfs.io
+          DEV_DOMAIN: dev.webui.ipfs.io
           BUILD_DIR: build
     steps:
       - attach_workspace:
@@ -43,6 +44,10 @@ jobs:
             echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
 
             if [ "$CIRCLE_BRANCH" == "master" ] ; then
+              dnslink-dnsimple -d $DEV_DOMAIN -r _dnslink -l /ipfs/$hash
+            fi
+
+            if [ ! -z "$CIRCLE_TAG" ] ; then
               dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
             fi
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In separate shells run the following:
 
 You must configure your IPFS API at http://127.0.0.1:5001  to allow [cross-origin (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests from your dev server at http://localhost:3000
 
-Similarly if you want to try out pre-release versions at https://webui.ipfs.io you need to add that as an allowed domain too.
+Similarly if you want to try out pre-release versions at https://dev.webui.ipfs.io you need to add that as an allowed domain too.
 
 #### Easy mode
 


### PR DESCRIPTION
@olizilla as far as I understood, all subdomains from `ipfs.io` are pinned to the gateway. This adds a `dev.webui.ipfs.io` subdomain for the latest commit and changes the current `webui.ipfs.io` to the latest **released version** and not commit.

On tags, we update **both** domains DNSLinks, otherwise we just update the development website.

Please let me know if there is anything else that should be done to enable the domain `dev.webui.ipfs.io`. I believe someone should set some CNAME or something like that.

Ref.: This blocks further progress on fixing IPFS Desktop CI issues: https://github.com/ipfs-shipyard/ipfs-desktop/issues/1055.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>