### PR TITLE
feat: share countly data with ipfs desktop

### DIFF
--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -242,7 +242,7 @@ const createAnalyticsBundle = ({
       removeConsent(name, store)
       dispatch({ type: 'ANALYTICS_REMOVE_CONSENT', payload: { name } })
     },
-    
+
     doAddConsent: (name) => ({ dispatch, store }) => {
       addConsent(name, store)
       dispatch({ type: 'ANALYTICS_ADD_CONSENT', payload: { name } })

--- a/src/bundles/ipfs-desktop.js
+++ b/src/bundles/ipfs-desktop.js
@@ -29,6 +29,8 @@ if (window.ipfsDesktop) {
 
     selectDesktopVersion: () => window.ipfsDesktop.version,
 
+    selectDesktopCountlyDeviceId: () => window.ipfsDesktop.countlyDeviceId,
+
     doDesktopStartListening: () => async ({ dispatch, store }) => {
       window.ipfsDesktop.onConfigChanged(({ config, changed, success }) => {
         const prevConfig = store.selectDesktopSettings()
@@ -75,6 +77,14 @@ if (window.ipfsDesktop) {
 
     doDesktopSelectDirectory: () => () => {
       return window.ipfsDesktop.selectDirectory()
+    },
+
+    doDesktopAddConsent: consent => () => {
+      return window.ipfsDesktop.addConsent(consent)
+    },
+
+    doDesktopRemoveConsent: consent => () => {
+      return window.ipfsDesktop.removeConsent(consent)
     },
 
     init: store => {


### PR DESCRIPTION
This allows Web UI to receive the Countly Key and Device ID from IPFS Desktop itself. With that, the data can be better analysed. Also, this shares the consents we make on Web UI so Desktop knows what to send and what not to.

Please see https://github.com/ipfs-shipyard/ipfs-desktop/issues/1063.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>