### PR TITLE
fix: draggable area on desktop

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,7 @@ export class App extends Component {
             <NavBar />
           </div>
           <div className='flex-auto-l'>
-            <div className='flex items-center ph3 ph4-l' style={{ height: 75, background: '#F0F6FA', paddingTop: '20px', paddingBottom: '15px' }}>
+            <div className='flex items-center ph3 ph4-l' style={{ webkitAppRegion: 'drag', height: 75, background: '#F0F6FA', paddingTop: '20px', paddingBottom: '15px' }}>
               <div className='joyride-app-explore' style={{ width: 560 }}>
                 <FilesExploreForm onBrowse={doFilesNavigateTo} onInspect={doExploreUserProvidedPath} />
               </div>


### PR DESCRIPTION
Increases the draggable area of IPFS Desktop. The new draggable area is (anywhere in the light blue area can be clicked to drag and move the window around):

![image](https://user-images.githubusercontent.com/5447088/64115145-c2dbb080-cd86-11e9-9337-ce2ae68bde09.png)

- Please see https://github.com/ipfs-shipyard/ipfs-desktop/pull/1071