### PR TITLE
feat: add 'ws' and 'wss' to peer connectivity

### DIFF
--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -252,10 +252,20 @@ const toLocationString = loc => {
   return city && country ? `${country}, ${city}` : country
 }
 
+const additionalProtos = ['ws', 'wss']
+
 const parseConnection = (multiaddr) => {
   const opts = multiaddr.toOptions()
+  const protos = multiaddr.protoNames()
+  let conn = `${opts.family}・${opts.transport}`
 
-  return `${opts.family}・${opts.transport}`
+  for (const proto of additionalProtos) {
+    if (protos.includes(proto)) {
+      conn = `${conn}・${proto}`
+    }
+  }
+
+  return conn
 }
 
 const parseLatency = (latency) => {


### PR DESCRIPTION
Fixes #1141. Adds 'ws' and 'wss' on WebSockets connectivities. **This is an alternative for #1167. Only one must be merged.**

![image](https://user-images.githubusercontent.com/5447088/64919842-9a50af00-d7a7-11e9-99bf-ae95eaa9385c.png)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>