### PR TITLE
feat: show all protocols in connectivity

### DIFF
--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -253,9 +253,7 @@ const toLocationString = loc => {
 }
 
 const parseConnection = (multiaddr) => {
-  const opts = multiaddr.toOptions()
-
-  return `${opts.family}・${opts.transport}`
+  return multiaddr.protoNames().join('・')
 }
 
 const parseLatency = (latency) => {


### PR DESCRIPTION
Fixes #1141. Shows all protocols in the connectivity column. **This is an alternative for #1166. Only one must be merged.**

![image](https://user-images.githubusercontent.com/5447088/64919838-84db8500-d7a7-11e9-800f-2910c545ff5e.png)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>