### PR TITLE
fix: correctly highlight p2p-circuit addresses

### DIFF
--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -3,11 +3,13 @@ import React from 'react'
 const Address = ({ value }) => {
   if (!value) return null
   const parts = value.split('/')
+  // used to shift the highlight one right on p2p-circuit addresses
+  const d = parts.includes('p2p-circuit') ? 1 : 0
   return (
     <div className='charcoal-muted monospace'>
       {parts.map((chunk, i) => (
         <span key={i}>
-          <span className={i % 2 || i > 4 ? 'force-select' : 'force-select charcoal'}>{chunk}</span>
+          <span className={(i - d) % 2 || (i - d) > 4 || (i - d) === 0 ? 'force-select' : 'force-select charcoal'}>{chunk}</span>
           {i < parts.length - 1 ? '/' : ''}
         </span>
       ))}


### PR DESCRIPTION
Fixes #1160. Shifts the highlight of `/p2p-circuit` addresses to the right, highlighting the IP address and the port.

I noticed there are some addresses that don't contain IP address, nor port. Should we perhaps disable the highlight on those? If so, that should be a different PR though.

![image](https://user-images.githubusercontent.com/5447088/64920192-5e6c1880-d7ac-11e9-84e2-1f5e692dba00.png)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>