### PR TITLE
feat: show full address on connectivity hover

### DIFF
--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -152,6 +152,7 @@ export default function (opts) {
           locationObj.latitude
         ]
         const connection = parseConnection(peer.addr)
+        const address = peer.addr.toString()
         const latency = parseLatency(peer.latency)
         const notes = parseNotes(peer, bootstrapPeers)
 
@@ -161,6 +162,7 @@ export default function (opts) {
           flagCode,
           coordinates,
           connection,
+          address,
           latency,
           notes
         }

--- a/src/peers/PeersTable/PeersTable.js
+++ b/src/peers/PeersTable/PeersTable.js
@@ -71,6 +71,12 @@ export class PeersTable extends React.Component {
     }
   }
 
+  connectionCellRenderer = ({ rowData }) => (
+    <abbr style={{ textDecoration: 'none' }} title={rowData.address}>
+      {rowData.connection}
+    </abbr>
+  )
+
   rowClassRenderer = ({ index }) => {
     return index === -1 ? 'bb b--near-white bg-near-white' : 'bb b--near-white'
   }
@@ -106,7 +112,7 @@ export class PeersTable extends React.Component {
               <Column label={t('location')} cellRenderer={this.locationCellRenderer} dataKey='location' width={450} className='f6 navy-muted truncate pl2' />
               <Column label={t('latency')} cellRenderer={this.latencyCellRenderer} dataKey='latency' width={250} className='f6 navy-muted monospace pl2' />
               <Column label={t('peerId')} cellRenderer={this.peerIdCellRenderer} dataKey='peerId' width={250} className='charcoal monospace truncate f7 pl2' />
-              <Column label={t('connection')} dataKey='connection' width={400} className='f6 navy-muted truncate pl2' />
+              <Column label={t('connection')} cellRenderer={this.connectionCellRenderer} dataKey='connection' width={400} className='f6 navy-muted truncate pl2' />
               <Column label={t('notes')} cellRenderer={this.notesCellRenderer} disableSort dataKey='notes' width={400} className='charcoal monospace truncate f7 pl2' />
             </Table>
           )}


### PR DESCRIPTION
Fixes #1141 by showing the full address on hover:

![image](https://user-images.githubusercontent.com/5447088/64920366-cc194400-d7ae-11e9-9ae4-da9b26f61c97.png)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>