### PR TITLE
fix: rename modal keeping the previous name

### DIFF
--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -119,8 +119,12 @@ class Modals extends React.Component {
         })
         break
       }
-      default:
+      case NEW_FOLDER:
+      case ADD_BY_PATH:
         this.setState({ readyToShow: true })
+        break
+      default:
+        return
     }
   }
 

--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -124,7 +124,7 @@ class Modals extends React.Component {
         this.setState({ readyToShow: true })
         break
       default:
-        return
+        // do nothing
     }
   }
 


### PR DESCRIPTION
Fixes #1215. The rename modal was getting updated when passing an `undefined`/`null` modal to show. At that time, it would tell the modals to show up, which was reusing the previous data.