### PR TITLE
fix: WebkitAppRegion is uppercase

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,7 +69,7 @@ export class App extends Component {
             <NavBar />
           </div>
           <div className='flex-auto-l'>
-            <div className='flex items-center ph3 ph4-l' style={{ webkitAppRegion: 'drag', height: 75, background: '#F0F6FA', paddingTop: '20px', paddingBottom: '15px' }}>
+            <div className='flex items-center ph3 ph4-l' style={{ WebkitAppRegion: 'drag', height: 75, background: '#F0F6FA', paddingTop: '20px', paddingBottom: '15px' }}>
               <div className='joyride-app-explore' style={{ width: 560 }}>
                 <FilesExploreForm onBrowse={doFilesNavigateTo} onInspect={doExploreUserProvidedPath} />
               </div>


### PR DESCRIPTION
Vendor-specific properties must start with an uppercase letter.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>