### PR TITLE
fix: disable launch on startup on unsupported platforms

### DIFF
--- a/src/settings/DesktopSettings.js
+++ b/src/settings/DesktopSettings.js
@@ -40,6 +40,7 @@ export function DesktopSettings ({ t, doDesktopSettingsToggle, desktopSettings }
 
       <CheckboxSetting checked={desktopSettings.autoLaunch || false}
         title={t('launchOnStartup')}
+        disabled={!['win32', 'darwin', 'linux'].includes(os.platform())}
         onChange={() => doDesktopSettingsToggle('autoLaunch')} />
       <CheckboxSetting checked={desktopSettings.ipfsOnPath || false}
         title={t('ipfsCmdTools')}

--- a/src/settings/DesktopSettings.js
+++ b/src/settings/DesktopSettings.js
@@ -40,7 +40,7 @@ export function DesktopSettings ({ t, doDesktopSettingsToggle, desktopSettings }
 
       <CheckboxSetting checked={desktopSettings.autoLaunch || false}
         title={t('launchOnStartup')}
-        disabled={!['win32', 'darwin', 'linux'].includes(os.platform())}
+        disabled={!(['win32', 'darwin', 'linux'].includes(os.platform()) && process.env.NODE_ENV !== 'development')}
         onChange={() => doDesktopSettingsToggle('autoLaunch')} />
       <CheckboxSetting checked={desktopSettings.ipfsOnPath || false}
         title={t('ipfsCmdTools')}


### PR DESCRIPTION
Disables launch on startup on OSes that are not Windows, macOS or Linux.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>