### PR TITLE
fix: peer count contrast on Peers screen

### DIFF
--- a/src/peers/WorldMap/WorldMap.js
+++ b/src/peers/WorldMap/WorldMap.js
@@ -36,9 +36,9 @@ const WorldMap = ({ t, className }) => {
         </div>
       </div>
       <div className='absolute bottom-0 left-0 right-0'>
-        <div className='flex flex-auto flex-column items-center self-end pb5-ns'>
-          <div className='f1 fw5 aqua'><PeersCount /></div>
-          <div className='f4 b ttu'>{t('peers')}</div>
+        <div className='flex flex-auto flex-column items-center self-end pb5-ns no-select'>
+          <div className='f1 fw5 black'><PeersCount /></div>
+          <div className='f4 b ttu charcoal-muted'>{t('peers')}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- change colors as suggested in https://github.com/ipfs-shipyard/ipfs-webui/issues/1277#issuecomment-546060437
- disable text selection (makes peer count feel like a part of the map)

closes #1277