### PR TITLE
fix: remove typo in 'IPFS is a web' description on Files screen

### DIFF
--- a/src/components/about-ipfs/AboutIpfs.js
+++ b/src/components/about-ipfs/AboutIpfs.js
@@ -13,7 +13,7 @@ export const AboutIpfs = ({ t }) => {
         <p><strong>IPFS is a filesystem.</strong> It has directories and files and mountable filesystem via FUSE.</p>
       </Trans>
       <Trans i18nKey='aboutIpfs.paragraph3'>
-        <p><strong>IPFS is a web.</strong> iles are accessible via HTTP gateways like <code className='f7'>https://ipfs.io</code>. Browsers <a className='link blue' target='_blank' rel='noopener noreferrer' href='https://github.com/ipfs-shipyard/ipfs-companion#release-channel'>can be extended</a> to use the <code className='f7'>ipfs://</code> scheme directly, and hash-addressed content guarantees authenticity</p>
+        <p><strong>IPFS is a web.</strong> Files are accessible via HTTP gateways like <code className='f7'>https://ipfs.io</code>. Browsers <a className='link blue' target='_blank' rel='noopener noreferrer' href='https://github.com/ipfs-shipyard/ipfs-companion#release-channel'>can be extended</a> to use the <code className='f7'>ipfs://</code> scheme directly, and hash-addressed content guarantees authenticity</p>
       </Trans>
       <Trans i18nKey='aboutIpfs.paragraph4'>
         <p><strong>IPFS is p2p.</strong> It supports worldwide peer-to-peer file transfers with a completely decentralized architecture and no central point of failure.</p>


### PR DESCRIPTION
Small typo that I noticed.