### PR TITLE
Allow vertical scroll in the navbar

### DIFF
--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -57,7 +57,7 @@ export const NavBar = ({ t, width, open, onToggle }) => {
   const gitRevision = process.env.REACT_APP_GIT_REV
   const revisionUrl = `${codeUrl}/commit/${gitRevision}`
   return (
-    <div className='h-100 fixed-l flex flex-column justify-between' style={{ width: 'inherit' }}>
+    <div className='h-100 fixed-l flex flex-column justify-between' style={{ overflowY: 'auto', width: 'inherit' }}>
       <div className='flex flex-column'>
         <div className='pointer navy pv3 pv4-l' onClick={onToggle}>
           <img className='center' style={{ height: 70, display: open ? 'block' : 'none' }} src={ipfsLogoText} alt='IPFS' title='Toggle navbar' />


### PR DESCRIPTION
This allows to scroll the navbar when your window is not tall enough to display the entire length.

![ipfs-scroll-navbar](https://user-images.githubusercontent.com/10872136/70184814-e9441b80-16e8-11ea-90f0-bbc894a5bdd3.gif)
