### PR TITLE
fix(files): do not double-decode paths in infoFromPath

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -126,7 +126,7 @@ const fetchFiles = make(ACTIONS.FETCH, async (ipfs, id, { store }) => {
 
   if (!isRoot) {
     const parentPath = dirname(path)
-    const parentInfo = infoFromPath(parentPath)
+    const parentInfo = infoFromPath(parentPath, false)
 
     if (parentInfo.isMfs || !parentInfo.isRoot) {
       if (parentInfo.realPath.startsWith('/ipns')) {

--- a/src/bundles/files/utils.js
+++ b/src/bundles/files/utils.js
@@ -82,7 +82,7 @@ export const sortFiles = (files, sorting) => {
   })
 }
 
-export const infoFromPath = (path) => {
+export const infoFromPath = (path, uriDecode = true) => {
   const info = {
     path: path,
     realPath: null,
@@ -118,8 +118,10 @@ export const infoFromPath = (path) => {
     info.realPath = info.realPath.substring(0, info.realPath.length - 1)
   }
 
-  info.realPath = decodeURIComponent(info.realPath)
-  info.path = decodeURIComponent(info.path)
+  if (uriDecode) {
+    info.realPath = decodeURIComponent(info.realPath)
+    info.path = decodeURIComponent(info.path)
+  }
 
   return info
 }


### PR DESCRIPTION
`infoFromPath` decodes the given path. If the path is already decoded, it will be re-decoded and breaks MFS paths like `/dapps/http/127.0.0.1%3A8080/ipns` (IPFS companion creates this).

This problem can be reproduced by running:

```
ipfs files mkdir /%3A/foo -p
```

and then visit `#/files/%253A/foo` in Web UI. (It says "Failed to get those files.")

This PR fixes the problem by not decoding the path that is already decoded.