### PR TITLE
fix: support POST-only HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Run the **[cors-config.sh](./cors-config.sh)** script with:
 
 ```sh
 > ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://localhost:3000", "https://webui.ipfs.io"]'
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'
 ```
 
 #### Reverting

--- a/cors-config.sh
+++ b/cors-config.sh
@@ -6,7 +6,7 @@ ALLOW_ORIGINS='"http://localhost:3000", "https://webui.ipfs.io"'
 set -e
 
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[$ALLOW_ORIGINS]"
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'
 
 echo "IPFS API CORS headers configured for $ALLOW_ORIGINS"
 echo "Please restart your IPFS daemon"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5530,6 +5530,11 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -11520,6 +11525,27 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "find-yarn-workspace-root": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
+      "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
+      "requires": {
+        "fs-extra": "^4.0.3",
+        "micromatch": "^3.1.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
       }
     },
     "flat-cache": {
@@ -40970,6 +40996,14 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -43296,6 +43330,37 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "patch-package": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
+      "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^1.2.1",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
     },
     "path-browserify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.7.2",
   "private": true,
   "scripts": {
+    "postinstall": "patch-package",
     "start": "run-script-os",
     "start:win32": "@powershell -Command $env:REACT_APP_GIT_REV=(git rev-parse --short HEAD); react-scripts start",
     "start:darwin:linux": "cross-env REACT_APP_GIT_REV=`git rev-parse --short HEAD` react-scripts start",
@@ -55,6 +56,7 @@
     "multiaddr": "^7.2.1",
     "multiaddr-to-uri": "^5.1.0",
     "p-queue": "^6.2.1",
+    "patch-package": "6.2.2",
     "prop-types": "^15.7.2",
     "pull-file-reader": "^1.0.2",
     "react": "^16.12.0",

--- a/patches/ipfs-http-client+39.0.2.patch
+++ b/patches/ipfs-http-client+39.0.2.patch
@@ -1,0 +1,91 @@
+diff --git a/node_modules/ipfs-http-client/src/config/profiles/list.js b/node_modules/ipfs-http-client/src/config/profiles/list.js
+index dbfa579..6f501f7 100644
+--- a/node_modules/ipfs-http-client/src/config/profiles/list.js
++++ b/node_modules/ipfs-http-client/src/config/profiles/list.js
+@@ -8,7 +8,7 @@ module.exports = configure(({ ky }) => {
+   return callbackify.variadic(async (options) => {
+     options = options || {}
+ 
+-    const res = await ky.get('config/profile/list', {
++    const res = await ky.post('config/profile/list', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers
+diff --git a/node_modules/ipfs-http-client/src/files-regular/get.js b/node_modules/ipfs-http-client/src/files-regular/get.js
+index 6c94264..68e15fe 100644
+--- a/node_modules/ipfs-http-client/src/files-regular/get.js
++++ b/node_modules/ipfs-http-client/src/files-regular/get.js
+@@ -36,7 +36,7 @@ module.exports = configure(({ ky }) => {
+       searchParams.set('length', options.length)
+     }
+ 
+-    const res = await ky.get('get', {
++    const res = await ky.post('get', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers,
+diff --git a/node_modules/ipfs-http-client/src/files-regular/ls.js b/node_modules/ipfs-http-client/src/files-regular/ls.js
+index 0f13f55..d81a963 100644
+--- a/node_modules/ipfs-http-client/src/files-regular/ls.js
++++ b/node_modules/ipfs-http-client/src/files-regular/ls.js
+@@ -31,7 +31,7 @@ module.exports = configure(({ ky }) => {
+       searchParams.set('recursive', options.recursive)
+     }
+ 
+-    const res = await ky.get('ls', {
++    const res = await ky.post('ls', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers,
+diff --git a/node_modules/ipfs-http-client/src/files-regular/refs-local.js b/node_modules/ipfs-http-client/src/files-regular/refs-local.js
+index efb8d32..afa1630 100644
+--- a/node_modules/ipfs-http-client/src/files-regular/refs-local.js
++++ b/node_modules/ipfs-http-client/src/files-regular/refs-local.js
+@@ -9,7 +9,7 @@ module.exports = configure(({ ky }) => {
+   return async function * refsLocal (options) {
+     options = options || {}
+ 
+-    const res = await ky.get('refs/local', {
++    const res = await ky.post('refs/local', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers
+diff --git a/node_modules/ipfs-http-client/src/files-regular/refs.js b/node_modules/ipfs-http-client/src/files-regular/refs.js
+index c6136ed..dbeb9a1 100644
+--- a/node_modules/ipfs-http-client/src/files-regular/refs.js
++++ b/node_modules/ipfs-http-client/src/files-regular/refs.js
+@@ -49,7 +49,7 @@ module.exports = configure(({ ky }) => {
+       searchParams.append('arg', arg.toString())
+     }
+ 
+-    const res = await ky.get('refs', {
++    const res = await ky.post('refs', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers,
+diff --git a/node_modules/ipfs-http-client/src/pubsub/ls.js b/node_modules/ipfs-http-client/src/pubsub/ls.js
+index 177dcd4..d2bc8f6 100644
+--- a/node_modules/ipfs-http-client/src/pubsub/ls.js
++++ b/node_modules/ipfs-http-client/src/pubsub/ls.js
+@@ -6,7 +6,7 @@ module.exports = configure(({ ky }) => {
+   return async (options) => {
+     options = options || {}
+ 
+-    const { Strings } = await ky.get('pubsub/ls', {
++    const { Strings } = await ky.post('pubsub/ls', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers,
+diff --git a/node_modules/ipfs-http-client/src/pubsub/peers.js b/node_modules/ipfs-http-client/src/pubsub/peers.js
+index bdeca60..5fa5b24 100644
+--- a/node_modules/ipfs-http-client/src/pubsub/peers.js
++++ b/node_modules/ipfs-http-client/src/pubsub/peers.js
+@@ -14,7 +14,7 @@ module.exports = configure(({ ky }) => {
+     const searchParams = new URLSearchParams(options.searchParams)
+     searchParams.set('arg', topic)
+ 
+-    const { Strings } = await ky.get('pubsub/peers', {
++    const { Strings } = await ky.post('pubsub/peers', {
+       timeout: options.timeout,
+       signal: options.signal,
+       headers: options.headers,

--- a/src/welcome/WelcomePage.js
+++ b/src/welcome/WelcomePage.js
@@ -74,7 +74,7 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
           </Trans>
           <Shell>
             <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '[{addOrigin && `"${origin}", `}"{defaultDomains.join('", "')}"]'</code>
-            <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'</code>
+            <code className='db'>$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'</code>
           </Shell>
         </div>
       )}


### PR DESCRIPTION
### Problem

https://github.com/ipfs/go-ipfs/pull/7097 will block `GET` commands on API port, requiring everything to be a POST request.

This breaks _Files_ screen in ipfs-webui as noted in https://github.com/ipfs-shipyard/ipfs-webui/issues/1429

### Even a bigger problem

ipfs-webui is using older version of js-ipfs-http-client, one before huge refactor into async iterables, which means switching to the latest version won't be a trivial task, as  the amount of code and dependencies that needs to be refactored is unknown.

### Solution

Due to time constraint I made a decision to patch it in npm `postinstall` so we can release this ASAP and ship with go-ipfs 0.5.

`postinstall` script will apply a simple patch on top of ipfs-http-client v39.0.2 to ensure it sends commands as POST

Proper fix will land when ipfs-webui is refactored to work with ipfs-http-client >41.x

Closes #1429

cc @achingbrain  for visibility 