### PR TITLE
Variable viewer height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ipfs-webui",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/files/file-preview/FilePreview.css
+++ b/src/files/file-preview/FilePreview.css
@@ -1,5 +1,5 @@
 .FilePreviewPDF {
-  height: calc(100vh - 140px - 5.5rem);
+  height: calc(100vh - 140px - 5.5rem);  /* 100% of viewport height, minus fixed-height search box and PDF info bar based on font height  */
   min-height: 100px;
 }
 

--- a/src/files/file-preview/FilePreview.css
+++ b/src/files/file-preview/FilePreview.css
@@ -5,6 +5,6 @@
 
 @media only screen and (max-width: 60em) {
   .FilePreviewPDF {
-    height: calc(100vh - 234px - 14rem);
+    height: calc(100vh - 234px - 14rem);   /* 100% of viewport height, minus fixed-height search box, page nav header, and PDF info bar based on font height  */
   }
 }

--- a/src/files/file-preview/FilePreview.css
+++ b/src/files/file-preview/FilePreview.css
@@ -1,0 +1,10 @@
+.FilePreviewPDF {
+  height: calc(100vh - 140px - 5.5rem);
+  min-height: 100px;
+}
+
+@media only screen and (max-width: 60em) {
+  .FilePreviewPDF {
+    height: calc(100vh - 234px - 14rem);
+  }
+}

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -5,6 +5,7 @@ import isBinary from 'is-binary'
 import { Trans, withTranslation } from 'react-i18next'
 import typeFromExt from '../type-from-ext'
 import ComponentLoader from '../../loader/ComponentLoader.js'
+import './FilePreview.css'
 
 class Preview extends React.Component {
   state = {
@@ -32,7 +33,7 @@ class Preview extends React.Component {
         )
       case 'pdf':
         return (
-          <object width='100%' height='500px' data={src} type='application/pdf'>
+          <object className="FilePreviewPDF w-100" data={src} type='application/pdf'>
             {t('noPDFSupport')}
             <a href={src} download target='_blank' rel='noopener noreferrer' className='underline-hover navy-muted'>{t('downloadPDF')}</a>
           </object>


### PR DESCRIPTION
- Makes PDF viewer height take up full screen height per #1434 
- Unfortunately can't be based entirely on Tachyons references since fixed pixel heights for assorted header items
- Side note: something similar may be happening in https://github.com/ipfs-shipyard/ipld-explorer/issues/53

closes #1434 