### PR TITLE
fix: translated tour guides for all pages

### DIFF
--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -1,3 +1,10 @@
 {
-  "tourTooltip": "Click this button any time for a guided tour on the current page."
+  "tour": {
+    "back": "Back",
+    "close": "Close",
+    "last": "Last",
+    "next": "Next",
+    "skip": "Skip",
+    "tooltip": "Click this button any time for a guided tour on the current page."
+  }
 }

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -78,6 +78,11 @@
   "addFilesInfo": "<0>Add files to your local IPFS node by clicking the <1>Add to IPFS</1> button above.</0>",
   "companionInfo": "<0>As you are using <1>IPFS Companion</1>, the files view is limited to files added while using the extension.</0>",
   "tour": {
+    "back": "Back",
+    "close": "Close",
+    "last": "Last",
+    "next": "Next",
+    "skip": "Skip",
     "step1": {
       "title": "Files page",
       "paragraph1": "<0>This is where the files on your <1>Mutable File System (MFS)</1> live. You can add files or folders and manage them from this page.</0>",

--- a/public/locales/en/peers.json
+++ b/public/locales/en/peers.json
@@ -15,6 +15,11 @@
   "add": "Add",
   "example": "Example:",
   "tour": {
+    "back": "Back",
+    "close": "Close",
+    "last": "Last",
+    "next": "Next",
+    "skip": "Skip",
     "step1": {
       "title": "Peers page",
       "paragraph1": "This is where you can see the peers that you are connected to and the country they are in.",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -67,6 +67,11 @@
     }
   },
   "tour": {
+    "back": "Back",
+    "close": "Close",
+    "last": "Last",
+    "next": "Next",
+    "skip": "Skip",
     "step1": {
       "title": "Settings page",
       "paragraph1": "Here you can change the settings of your Web UI and IPFS node.",

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -45,6 +45,11 @@
     "detailsLabel": "More info"
   },
   "tour": {
+    "back": "Back",
+    "close": "Close",
+    "last": "Last",
+    "next": "Next",
+    "skip": "Skip",
     "step1": {
       "title": "Status page",
       "paragraph1": "This is the starting point of your IPFS node and where you can check its basic info.",

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { DropTarget } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 // Lib
 import { appTour } from './lib/tours'
+import { getJoyrideLocales } from './helpers/i8n'
 // Components
 import NavBar from './navigation/NavBar'
 import ComponentLoader from './loader/ComponentLoader'
@@ -93,7 +94,9 @@ export class App extends Component {
           styles={appTour.styles}
           callback={this.handleJoyrideCb}
           scrollToFirstStep
-          disableOverlay />
+          disableOverlay
+          locale={getJoyrideLocales(t)}
+        />
 
         <Notify />
       </div>

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -14,6 +14,8 @@ import withTour from '../components/tour/withTour'
 import InfoBoxes from './info-boxes/InfoBoxes'
 import FilePreview from './file-preview/FilePreview'
 import FilesList from './files-list/FilesList'
+import { getJoyrideLocales } from '../helpers/i8n'
+
 // Icons
 import Modals, { DELETE, NEW_FOLDER, SHARE, RENAME, ADD_BY_PATH } from './modals/Modals'
 import Header from './header/Header'
@@ -263,6 +265,7 @@ class FilesPage extends React.Component {
           callback={handleJoyrideCallback}
           continuous
           scrollToFirstStep
+          locale={getJoyrideLocales(t)}
           showProgress />
       </div>
     )

--- a/src/helpers/i8n.js
+++ b/src/helpers/i8n.js
@@ -1,0 +1,8 @@
+
+export const getJoyrideLocales = (translate) => ({
+  back: translate('tour.back'),
+  close: translate('tour.close'),
+  last: translate('tour.last'),
+  next: translate('tour.next'),
+  skip: translate('tour.skip')
+})

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -3,7 +3,7 @@ import React from 'react'
 export const appTour = {
   getSteps: ({ t }) => [{
     content: <div className='montserrat white'>
-      <p className='ma0 pa0 tl f6'>{t('tourTooltip')}</p>
+      <p className='ma0 pa0 tl f6'>{t('tour.tooltip')}</p>
     </div>,
     placement: 'left',
     target: '.joyride-app-tour',

--- a/src/peers/PeersPage.js
+++ b/src/peers/PeersPage.js
@@ -5,6 +5,7 @@ import { withTranslation } from 'react-i18next'
 import ReactJoyride from 'react-joyride'
 import withTour from '../components/tour/withTour'
 import { peersTour } from '../lib/tours'
+import { getJoyrideLocales } from '../helpers/i8n'
 
 // Components
 import Box from '../components/box/Box'
@@ -34,6 +35,7 @@ const PeersPage = ({ t, toursEnabled, handleJoyrideCallback }) => (
       callback={handleJoyrideCallback}
       continuous
       scrollToFirstStep
+      locale={getJoyrideLocales(t)}
       showProgress />
   </div>
 )

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -6,6 +6,7 @@ import ReactJoyride from 'react-joyride'
 // Tour
 import { settingsTour } from '../lib/tours'
 import withTour from '../components/tour/withTour'
+import { getJoyrideLocales } from '../helpers/i8n'
 // Components
 import Tick from '../icons/GlyphSmallTick'
 import Box from '../components/box/Box'
@@ -103,6 +104,7 @@ export const SettingsPage = ({
       callback={handleJoyrideCallback}
       continuous
       scrollToFirstStep
+      locale={getJoyrideLocales(t)}
       showProgress />
   </div>
 )

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -13,6 +13,7 @@ import NetworkTraffic from './NetworkTraffic'
 import Box from '../components/box/Box'
 import AskToEnable from '../components/ask/AskToEnable'
 import { statusTour } from '../lib/tours'
+import { getJoyrideLocales } from '../helpers/i8n'
 import withTour from '../components/tour/withTour'
 
 const StatusPage = ({
@@ -79,6 +80,7 @@ const StatusPage = ({
           callback={handleJoyrideCallback}
           continuous
           scrollToFirstStep
+          locale={getJoyrideLocales(t)}
           showProgress />
       </div>
     </div>


### PR DESCRIPTION
Fixes #1439

A future improved solution would be to re-use all the repeated translations, but the current architecture doesn't allow it.