### PR TITLE
fix: console error when no API available

### DIFF
--- a/src/welcome/WelcomePage.js
+++ b/src/welcome/WelcomePage.js
@@ -30,7 +30,7 @@ const WelcomePage = ({ t, doUpdateIpfsApiAddress, apiUrl, ipfsInitFailed, ipfsCo
             </Trans>
             <ApiAddressForm
               t={t}
-              defaultValue={ipfsApiAddress}
+              defaultValue={ipfsApiAddress || ''}
               updateAddress={doUpdateIpfsApiAddress} />
           </Box>
         </div>


### PR DESCRIPTION
This PR removes error in console  when there is no API available:

![error-when-down-2020-04-18--01-56-26](https://user-images.githubusercontent.com/157609/79623064-8f357700-811a-11ea-9751-11a6d6df15ce.png)
