### PR TITLE
fix: drag n drop now works if outside the file area

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -167,7 +167,7 @@ export default () => ({
     }
   },
 
-  doFilesWrite: make(ACTIONS.WRITE, async (ipfs, files, root = '', id, { dispatch }) => {
+  doFilesWrite: make(ACTIONS.WRITE, async (ipfs, files, root, id, { dispatch }) => {
     files = files.filter(f => !IGNORED_FILES.includes(basename(f.path)))
     const totalSize = files.reduce((prev, { size }) => prev + size, 0)
 

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -167,7 +167,7 @@ export default () => ({
     }
   },
 
-  doFilesWrite: make(ACTIONS.WRITE, async (ipfs, files, root, id, { dispatch }) => {
+  doFilesWrite: make(ACTIONS.WRITE, async (ipfs, files, root = '', id, { dispatch }) => {
     files = files.filter(f => !IGNORED_FILES.includes(basename(f.path)))
     const totalSize = files.reduce((prev, { size }) => prev + size, 0)
 
@@ -210,7 +210,7 @@ export default () => ({
       // Only go for direct children
       if (path.indexOf('/') === -1 && path !== '') {
         const src = `/ipfs/${hash}`
-        const dst = join(realMfsPath(root), path)
+        const dst = join(realMfsPath(root || '/files'), path)
 
         try {
           await ipfs.files.cp([src, dst])


### PR DESCRIPTION
Possible fix for #1367

### Notes

- Drag n dropping outside the "files" area would result in the error reported in the issue. However, drag n dropping in the "files" would work just fine with the same file. After some investigation, the `root` property appears to be undefined when dragging outside the zone 🤷 