### PR TITLE
fix: switch CI build to Node 12.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.15.1-browsers
+      - image: circleci/node:12.16.2-browsers-legacy
         environment:
           NO_SANDBOX: true
     steps:


### PR DESCRIPTION
For some reason unit tests fail on CI, low hanging fruit is to update CI to Node 12.x 