### PR TITLE
fix: updated languages.json using lol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ipfs-webui",
-  "version": "2.7.5",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/languages.json
+++ b/src/lib/languages.json
@@ -29,6 +29,16 @@
     "nativeName": "Français",
     "englishName": "French"
   },
+  "it": {
+    "locale": "it",
+    "nativeName": "Italiano",
+    "englishName": "Italian"
+  },
+  "ja-JP": {
+    "locale": "ja-JP",
+    "nativeName": "日本語",
+    "englishName": "Japanese"
+  },
   "ko-KR": {
     "locale": "ko-KR",
     "nativeName": "한국어 (韩国)",
@@ -54,6 +64,16 @@
     "nativeName": "Português",
     "englishName": "Portuguese"
   },
+  "ru": {
+    "locale": "ru",
+    "nativeName": "Русский",
+    "englishName": "Russian"
+  },
+  "sk": {
+    "locale": "sk",
+    "nativeName": "Slovenčina",
+    "englishName": "Slovak"
+  },
   "sv": {
     "locale": "sv",
     "nativeName": "Svenska",
@@ -63,6 +83,11 @@
     "locale": "zh-CN",
     "nativeName": "中文（中国）",
     "englishName": "Chinese Simplified (China)"
+  },
+  "zh-HK": {
+    "locale": "zh-HK",
+    "nativeName": "中文（香港）",
+    "englishName": "Chinese Traditional (Hong Kong)"
   },
   "zh-TW": {
     "locale": "zh-TW",


### PR DESCRIPTION
Looks like language choices were displaying as "English" in the choose-language modal due to their being missing from `languages.json`.

- If it's a matter of having just forgotten to update the contents of `languages.json` after manually running `lol`, this PR addresses that.
- If `lol` is being run automatically and updating `languages.json` as some part of our deploy process, and I missed that, there's a larger problem as of yet unresolved.

Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1471