### PR TITLE
fix(i18n): 'File name' → 'Name'

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -6,7 +6,7 @@
   "totalSize": "Total size: {size}",
   "filesSelected": "{count, plural, one {File selected} other {Files selected}}",
   "individualFilesOnly": "Only available for individual files",
-  "fileName": "File name",
+  "itemName": "Name",
   "size": "Size",
   "noPDFSupport": "Your browser does not support PDFs. Please download the PDF to view it:",
   "downloadPDF": "Download PDF",

--- a/src/components/loading-animation/LoadingAnimation.js
+++ b/src/components/loading-animation/LoadingAnimation.js
@@ -10,7 +10,7 @@ import './LoadingAnimation.css'
 const FakeHeader = ({ t }) => (
   <header className='gray pv2 flex items-center flex-none'>
     <div className='pa2 w2'><Checkbox disabled /></div>
-    <div className='ph2 f6 flex-auto'>{t('fileName')}</div>
+    <div className='ph2 f6 flex-auto'>{t('itemName')}</div>
     <div className='pl2 pr4 tr f6 flex-none dn db-l'>{t('size')}</div>
     <div className='pa2' style={{ width: '2.5rem' }} />
   </header>

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -385,7 +385,7 @@ export class FilesList extends React.Component {
               </div>
               <div className='ph2 f6 flex-auto'>
                 <span onClick={this.changeSort(sorts.BY_NAME)} className='pointer'>
-                  {t('fileName')} {this.sortByIcon(sorts.BY_NAME)}
+                  {t('itemName')} {this.sortByIcon(sorts.BY_NAME)}
                 </span>
               </div>
               <div className='ph2 pv1 flex-none dn db-l tr mw3'>


### PR DESCRIPTION
This is a fix for UX issue raised by @mirorauhala on Transifex:

>  Should be 'Name' since the list also lists folders. Makes it very
>  confusing that the column name is 'File name' yet it also lists folders
>  that aren't files.