### PR TITLE
fix(i18n): restoring translation of remaining strings

### DIFF
--- a/public/locales/cs/welcome.json
+++ b/public/locales/cs/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Beží vaše IPFS služba?",
     "paragraph1": "<0>Připojení k API selhalo.</0>",
-    "paragraoh2": "<0>Ujistěte se, že <1>nakonfigurujete své rozhraní IPFS API</1> tak, aby umožňovalo požadavky křížového původu (CORS), spuštěním následujících příkazů:</0>",
+    "paragraph2": "<0>Ujistěte se, že <1>nakonfigurujete své rozhraní IPFS API</1> tak, aby umožňovalo požadavky křížového původu (CORS), spuštěním následujících příkazů:</0>",
     "paragraph3": "<0>Spusťte démona IPFS v terminálu:</0>",
     "paragraph4": "<0>Pro více informací jak začít s IPFS si můžete <1>přečíst příručku</1>.</0>"
   },

--- a/public/locales/da/welcome.json
+++ b/public/locales/da/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Kører din IPFS baggrunds-process?",
     "paragraph1": "<0>Mislykkedes med at forbinde til API'et.</0>",
-    "paragraoh2": "<0>Sørg for at du <1>konfigurerer dit IPFS API</1> til at tillade cross-origin (CORS) forespørgsler, som afvikler kommandoerne nedenfor:</0>",
+    "paragraph2": "<0>Sørg for at du <1>konfigurerer dit IPFS API</1> til at tillade cross-origin (CORS) forespørgsler, som afvikler kommandoerne nedenfor:</0>",
     "paragraph3": "<0>Kør en IPFS-baggrundsprocess fra en terminal:</0>",
     "paragraph4": "<0>For mere info om at komme i gang med IPFS, kan du <1>læse guiden</1>.</0>"
   },

--- a/public/locales/de/welcome.json
+++ b/public/locales/de/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Läuft dein IPFS-Daemon?",
     "paragraph1": "<0>API-Verbindung fehlgeschlagen.</0>",
-    "paragraoh2": "<0>Stelle sicher, dass Du <1>Deine IPFS-API so konfigurierst</1>, dass mit den unten stehenden Befehlen Cross-Origin-Anfragen (CORS) zugelassen werden.</0>",
+    "paragraph2": "<0>Stelle sicher, dass Du <1>Deine IPFS-API so konfigurierst</1>, dass mit den unten stehenden Befehlen Cross-Origin-Anfragen (CORS) zugelassen werden.</0>",
     "paragraph3": "<0>Starte einen IPFS-Daemon in einem Terminal.</0>",
     "paragraph4": "<0><1>Lies die Anleitung</1> für mehr Informationen über das IPFS.</0>"
   },

--- a/public/locales/en/welcome.json
+++ b/public/locales/en/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Is your IPFS daemon running?",
     "paragraph1": "<0>Failed to connect to the API.</0>",
-    "paragraoh2": "<0>Make sure you <1>configure your IPFS API</1> to allow cross-origin (CORS) requests, running the commands below:</0>",
+    "paragraph2": "<0>Make sure you <1>configure your IPFS API</1> to allow cross-origin (CORS) requests, running the commands below:</0>",
     "paragraph3": "<0>Start an IPFS daemon in a terminal:</0>",
     "paragraph4": "<0>For more info on how to get started with IPFS you can <1>read the guide</1>.</0>"
   },

--- a/public/locales/es/welcome.json
+++ b/public/locales/es/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "¿Está funcionando su daemon IPFS?",
     "paragraph1": "<0>Error al conectarse a la API.</0>",
-    "paragraoh2": "<0>Asegúrese de <1>configurar su IPFS API</1> para permitir solicitudes de origen cruzado (CORS), ejecutando los siguientes comandos:</0>",
+    "paragraph2": "<0>Asegúrese de <1>configurar su IPFS API</1> para permitir solicitudes de origen cruzado (CORS), ejecutando los siguientes comandos:</0>",
     "paragraph3": "<0>Inicie un demonio IPFS en una terminal:</0>",
     "paragraph4": "<0>Para obtener más información sobre cómo comenzar con IPFS, puede <1>leer la guía</1>.</0>"
   },

--- a/public/locales/fr/welcome.json
+++ b/public/locales/fr/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Votre démon IPFS est-il en cours d'exécution ?",
     "paragraph1": "<0>Échec de connexion à l'API.</0>",
-    "paragraoh2": "<0>Assurez-vous de <1>configurer votre API IPFS</1>pour autoriser les requêtes cross-origin (CORS), en lançant la commande ci-dessous :</0>",
+    "paragraph2": "<0>Assurez-vous de <1>configurer votre API IPFS</1>pour autoriser les requêtes cross-origin (CORS), en lançant la commande ci-dessous :</0>",
     "paragraph3": "<0>Démarrer un démon IPFS dans un terminal :</0>",
     "paragraph4": "<0>Pour plus d'information sur comment démarrer avec IPFS vous pouvez <1> lire le manuel</1>.</0>"
   },

--- a/public/locales/it/welcome.json
+++ b/public/locales/it/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "È in esecuzione il demone IPFS?",
     "paragraph1": "<0>Connessione all'API fallita.</0>",
-    "paragraoh2": "<0>Accertati di <1>configurare la tua API IPFS</1> per permettere le richieste cross-origin (CORS), eseguendo i comandi sottostanti:</0>",
+    "paragraph2": "<0>Accertati di <1>configurare la tua API IPFS</1> per permettere le richieste cross-origin (CORS), eseguendo i comandi sottostanti:</0>",
     "paragraph3": "<0>Avvia un demone IPFS in un terminale:</0>",
     "paragraph4": "<0>Per ulteriori informazioni su come iniziare con IPFS puoi <1>leggere la guida</1>.</0>"
   },

--- a/public/locales/nl/welcome.json
+++ b/public/locales/nl/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Draait je IPFS daemon?",
     "paragraph1": "<0>Verbinden het de API mislukt.</0>",
-    "paragraoh2": "<0>Configureer zeker je <1>IPFS API</1>om cross-origin (CORS) aanvragen toe te staan. Dit kan met volgende commando's:</0>",
+    "paragraph2": "<0>Configureer zeker je <1>IPFS API</1>om cross-origin (CORS) aanvragen toe te staan. Dit kan met volgende commando's:</0>",
     "paragraph3": "<0>Start een IPFS daemon in een terminal:</0>",
     "paragraph4": "<0>Lees <1>de handleiding</1> om te starten met IPFS.</0> "
   },

--- a/public/locales/no/welcome.json
+++ b/public/locales/no/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "Kjører din IPFS daemon?",
     "paragraph1": "<0>Kunne ikke koble til API.</0>",
-    "paragraoh2": "<0>Vær sikker på at du <1>konfigurerer ditt IPFS API</1> til å tillate cross-origin (CORS) forespørsler, ved å kjøre kommandoene nedenfor:</0>",
+    "paragraph2": "<0>Vær sikker på at du <1>konfigurerer ditt IPFS API</1> til å tillate cross-origin (CORS) forespørsler, ved å kjøre kommandoene nedenfor:</0>",
     "paragraph3": "<0>Start en IPFS daemon i terminal:</0>",
     "paragraph4": "<0>For mer informasjon om hvordan du kommer i gang med IPFS kan du <1>lese guiden</1>.</0>"
   },

--- a/public/locales/pt/welcome.json
+++ b/public/locales/pt/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "O seu IPFS daemon está correr?",
     "paragraph1": "<0>Falha ao conectar à API.</0>",
-    "paragraoh2": "<0>Certifique-se que <1>configurou a sua API IPFS</1> para permitir pedidos de origem cruzada (CORS), executando os comandos abaixo:</0>",
+    "paragraph2": "<0>Certifique-se que <1>configurou a sua API IPFS</1> para permitir pedidos de origem cruzada (CORS), executando os comandos abaixo:</0>",
     "paragraph3": "<0>Inicie o IPFS no terminal:</0>",
     "paragraph4": "<0>Para mais informação sobre como iniciar a sua jornada com o IPFS, pode <1>ler o guia</1>.</0>"
   },

--- a/public/locales/zh-CN/welcome.json
+++ b/public/locales/zh-CN/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "您的 IPFS 守护程序是否正在运行？",
     "paragraph1": "<0>无法连接 API</0>",
-    "paragraoh2": "<0>确认你<1>配置了你的 IPFS API </1>以允许跨域（CORS）请求，执行下面命令：</0>",
+    "paragraph2": "<0>确认你<1>配置了你的 IPFS API </1>以允许跨域（CORS）请求，执行下面命令：</0>",
     "paragraph3": "<0>在终端中启动 IPFS 守护进程:</0>",
     "paragraph4": "<0>获取开始使用 IPFS 的更多信息你可以 <1>阅读此向导</1>.</0>"
   },

--- a/public/locales/zh-HK/welcome.json
+++ b/public/locales/zh-HK/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "您的 IPFS 執行程序是否正在運行？",
     "paragraph1": "<0>無法連接到 API。</0>",
-    "paragraoh2": "<0>請確保<1>你配置的 IPFS API</1> 以允許跨源（CORS）請求，運行以下命令：</0>",
+    "paragraph2": "<0>請確保<1>你配置的 IPFS API</1> 以允許跨源（CORS）請求，運行以下命令：</0>",
     "paragraph3": "<0>在終端機中啟動 IPFS 執行程序：</0>",
     "paragraph4": "<0>有關如何開始使用IPFS的更多信息，您可以<1>閱讀指南</1>。</0>"
   },

--- a/public/locales/zh-TW/welcome.json
+++ b/public/locales/zh-TW/welcome.json
@@ -16,7 +16,7 @@
   "notConnected": {
     "header": "您的 IPFS 守護程序是否正在運行？",
     "paragraph1": "<0>無法連接 API</0>",
-    "paragraoh2": "<0>確認你<1>配置了你的 IPFS API </1>以允許跨域（CORS）請求，執行下面命令：</0>",
+    "paragraph2": "<0>確認你<1>配置了你的 IPFS API </1>以允許跨域（CORS）請求，執行下面命令：</0>",
     "paragraph3": "<0>在終端中啟動 IPFS 守護進程:</0>",
     "paragraph4": "<0>獲取開始使用 IPFS 的更多信息你可以 <1>閱讀此嚮導</1>.</0>"
   },

--- a/src/components/about-ipfs/AboutIpfs.js
+++ b/src/components/about-ipfs/AboutIpfs.js
@@ -6,19 +6,19 @@ export const AboutIpfs = ({ t }) => {
   return (
     <Box>
       <h1 className='mt0 mb3 montserrat fw4 f4 charcoal'>{t('aboutIpfs.header')}</h1>
-      <Trans i18nKey='aboutIpfs.paragraph1'>
+      <Trans i18nKey='aboutIpfs.paragraph1' t={t}>
         <p className='mt0'><strong>IPFS is a protocol</strong> that defines a content-addressed file system, coordinates content delivery and combines ideas from Kademlia, BitTorrent, Git and more.</p>
       </Trans>
-      <Trans i18nKey='aboutIpfs.paragraph2'>
+      <Trans i18nKey='aboutIpfs.paragraph2' t={t}>
         <p><strong>IPFS is a filesystem.</strong> It has directories and files and mountable filesystem via FUSE.</p>
       </Trans>
-      <Trans i18nKey='aboutIpfs.paragraph3'>
+      <Trans i18nKey='aboutIpfs.paragraph3' t={t}>
         <p><strong>IPFS is a web.</strong> Files are accessible via HTTP gateways like <code className='f7'>https://ipfs.io</code>. Browsers <a className='link blue' target='_blank' rel='noopener noreferrer' href='https://github.com/ipfs-shipyard/ipfs-companion#release-channel'>can be extended</a> to use the <code className='f7'>ipfs://</code> scheme directly, and hash-addressed content guarantees authenticity</p>
       </Trans>
-      <Trans i18nKey='aboutIpfs.paragraph4'>
+      <Trans i18nKey='aboutIpfs.paragraph4' t={t}>
         <p><strong>IPFS is p2p.</strong> It supports worldwide peer-to-peer file transfers with a completely decentralized architecture and no central point of failure.</p>
       </Trans>
-      <Trans i18nKey='aboutIpfs.paragraph5'>
+      <Trans i18nKey='aboutIpfs.paragraph5' t={t}>
         <p><strong>IPFS is a CDN.</strong> Add a file to your local repository, and it's now available to the world with cache-friendly content-hash addressing and bittorrent-like bandwidth distribution.</p>
       </Trans>
     </Box>

--- a/src/components/analytics-toggle/AnalyticsToggle.js
+++ b/src/components/analytics-toggle/AnalyticsToggle.js
@@ -76,7 +76,7 @@ const AnalyticsToggle = ({ analyticsActionsToRecord, analyticsConsent, doToggleC
         <p>{t('AnalyticsToggle.paragraph1')}</p>
         <Details summaryText={t('AnalyticsToggle.summary')} className='pt2' open={open}>
           <p>
-            <Trans i18nKey='AnalyticsToggle.paragraph2'>
+            <Trans i18nKey='AnalyticsToggle.paragraph2' t={t}>
               Protocol Labs hosts a <a className='link blue' href='https://count.ly/'>Countly</a> instance to record anonymous usage data for this app.
             </Trans>
           </p>
@@ -88,7 +88,7 @@ const AnalyticsToggle = ({ analyticsActionsToRecord, analyticsConsent, doToggleC
             summary={t('AnalyticsToggle.sessions.summary')}
             sourceLink='https://github.com/Countly/countly-sdk-web/blob/93442edbe8c108618c88cc9e1ad179892c42940b/lib/countly.js#L1885-L1953'
             exampleRequest='https://countly.ipfs.io/i?begin_session=1&metrics=%7B%22_app_version%22%3A%222.4.0%22%2C%22_ua%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X%2010_14_2)%20AppleWebKit%2F537.36%20(KHTML%2C%20like%20Gecko)%20Chrome%2F72.0.3626.121%20Safari%2F537.36%22%2C%22_resolution%22%3A%221920x1080%22%2C%22_density%22%3A2%2C%22_locale%22%3A%22en-GB%22%7D&app_key=700fd825c3b257e021bd9dbc6cbf044d33477531&device_id=804117b1-c21d-4e55-a65f-f9dbbe9a1f91&sdk_name=javascript_native_web&sdk_version=19.02.1&timestamp=1552296210554&hour=9&dow=1&consent=%7B%22sessions%22%3Atrue%2C%22events%22%3Atrue%2C%22views%22%3Atrue%2C%22location%22%3Atrue%2C%22crashes%22%3Atrue%7D'>
-            <Trans i18nKey='AnalyticsToggle.sessions.details'>
+            <Trans i18nKey='AnalyticsToggle.sessions.details' t={t}>
               <p>The following browser metrics are sent</p>
               <ul>
                 <li>A random, generated device ID</li>
@@ -111,7 +111,7 @@ const AnalyticsToggle = ({ analyticsActionsToRecord, analyticsConsent, doToggleC
             sourceLink='https://github.com/ipfs-shipyard/ipfs-webui/blob/30a077efe5198bf6403681b094ab585a88395c40/src/bundles/analytics.js#L93-L111'
             exampleRequest='https://countly.ipfs.io/i?events=%5B%7B%22key%22%3A%22FILES_MAKEDIR%22%2C%22count%22%3A1%2C%22dur%22%3A0.015194999985396862%2C%22timestamp%22%3A1552296333639%2C%22hour%22%3A9%2C%22dow%22%3A1%7D%5D&app_key=700fd825c3b257e021bd9dbc6cbf044d33477531&device_id=804117b1-c21d-4e55-a65f-f9dbbe9a1f91&sdk_name=javascript_native_web&sdk_version=19.02.1&timestamp=1552296333640&hour=9&dow=1'>
             <p>
-              <Trans i18nKey='AnalyticsToggle.events.details'>
+              <Trans i18nKey='AnalyticsToggle.events.details' t={t}>
                 App specific actions. We record only that the action happened, how long it took from start to finish, and a count if the event involved multiple items.
               </Trans>
             </p>
@@ -152,7 +152,7 @@ const AnalyticsToggle = ({ analyticsActionsToRecord, analyticsConsent, doToggleC
             sourceLink='https://github.com/ipfs-shipyard/ipfs-webui/blob/2fb9df4e7b294f26b35b1dd76084fe85672b6f2b/src/bundles/analytics.js#L115-L121'
             exampleRequest='https://countly.ipfs.io/i?crash=%7B%22_resolution%22%3A%221920x1080%22%2C%22_error%22%3A%22Error%3A%20example%20error%5Cn%20%20%20%20at%20Object._callee%24%20(http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A192105%3A63)%5Cn%20%20%20%20at%20tryCatch%20(http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A173974%3A40)%5Cn%20%20%20%20at%20Generator.invoke%20%5Bas%20_invoke%5D%20(http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A174208%3A22)%5Cn%20%20%20%20at%20Generator.prototype.(anonymous%20function)%20%5Bas%20next%5D%20(http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A174026%3A21)%5Cn%20%20%20%20at%20step%20(http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A192086%3A191)%5Cn%20%20%20%20at%20http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A192086%3A361%22%2C%22_app_version%22%3A%222.4.0%22%2C%22_run%22%3A5%2C%22_not_os_specific%22%3Atrue%2C%22_online%22%3Atrue%2C%22_background%22%3Atrue%2C%22_logs%22%3A%22STATS_FETCH_FAILED%22%2C%22_nonfatal%22%3Atrue%2C%22_view%22%3A%22%2F%23%2Fsettings%22%2C%22_custom%22%3Anull%2C%22_opengl%22%3A%22WebGL%201.0%20(OpenGL%20ES%202.0%20Chromium)%22%7D&app_key=700fd825c3b257e021bd9dbc6cbf044d33477531&device_id=d96d67ff-4797-45da-83b4-9e8f599cd12a&sdk_name=javascript_native_web&sdk_version=19.02.1&timestamp=1552294449012&hour=8&dow=1'>
             <p>
-              <Trans i18nKey='AnalyticsToggle.crashes.details'>
+              <Trans i18nKey='AnalyticsToggle.crashes.details' t={t}>
                 Records JavaScript error messages and stack traces that occur while using the app, where possible. It is very helpful to know when the app is not working for you, but <b>error messages may include identifiable information</b> like CIDs or file paths, so only enable this if you are comfortable sharing that information with us.
               </Trans>
             </p>

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -141,7 +141,7 @@ class FilesPage extends React.Component {
   }
 
   get mainView () {
-    const { files, doExploreUserProvidedPath } = this.props
+    const { t, files, doExploreUserProvidedPath } = this.props
 
     if (!files) {
       return (<div></div>)
@@ -154,7 +154,7 @@ class FilesPage extends React.Component {
 
       return (
         <div>
-          <Trans i18nKey='cidNotFileNorDir'>
+          <Trans i18nKey='cidNotFileNorDir' t={t}>
             The current link isn't a file, nor a directory. Try to <span className='link blue pointer' onClick={() => doExploreUserProvidedPath(path)}>inspect</span> it instead.
           </Trans>
         </div>

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -51,7 +51,7 @@ class Preview extends React.Component {
           <div className='mt4'>
             <p className='b'>{t('cantBePreviewed')} <span role='img' aria-label='sad'>😢</span></p>
             <p>
-              <Trans i18nKey='downloadInstead'>
+              <Trans i18nKey='downloadInstead' t={t}>
                 Try <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue' >downloading</a> it instead.
               </Trans>
             </p>

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -277,7 +277,7 @@ export class FilesList extends React.Component {
   }
 
   emptyRowsRenderer = () => {
-    const { upperDir, isOver, canDrop, onNavigate, onAddFiles } = this.props
+    const { t, upperDir, isOver, canDrop, onNavigate, onAddFiles } = this.props
     const { isDragging, focused } = this.state
 
     return (
@@ -296,7 +296,7 @@ export class FilesList extends React.Component {
           cantSelect
           {...upperDir} /> }
 
-        <Trans i18nKey='filesList.noFiles'>
+        <Trans i18nKey='filesList.noFiles' t={t}>
           <div className='pv3 b--light-gray bt tc gray f6'>
             There are no available files. Add some!
           </div>

--- a/src/files/info-boxes/add-files-info/AddFilesInfo.js
+++ b/src/files/info-boxes/add-files-info/AddFilesInfo.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { withTranslation, Trans } from 'react-i18next'
 import Box from '../../../components/box/Box'
 
-const AddFilesInfo = () => (
+const AddFilesInfo = ({ t }) => (
   <div className='mv4 tc navy f5' >
     <Box style={{ background: 'rgba(105, 196, 205, 0.1)' }}>
-      <Trans i18nKey='addFilesInfo'>
+      <Trans i18nKey='addFilesInfo' t={t}>
         <p className='ma0'>Add files to your local IPFS node by clicking the <strong>Add to IPFS</strong> button above.</p>
       </Trans>
     </Box>

--- a/src/files/info-boxes/companion-info/CompanionInfo.js
+++ b/src/files/info-boxes/companion-info/CompanionInfo.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { withTranslation, Trans } from 'react-i18next'
 import Box from '../../../components/box/Box'
 
-const CompanionInfo = () => (
+const CompanionInfo = ({ t }) => (
   <div className='mv4 tc navy f5' >
     <Box style={{ background: 'rgba(105, 196, 205, 0.1)' }}>
-      <Trans i18nKey='companionInfo'>
+      <Trans i18nKey='companionInfo' t={t}>
         <p className='ma0'>As you are using <strong>IPFS Companion</strong>, the files view is limited to files added while using the extension.</p>
       </Trans>
     </Box>

--- a/src/files/info-boxes/welcome-info/WelcomeInfo.js
+++ b/src/files/info-boxes/welcome-info/WelcomeInfo.js
@@ -8,22 +8,22 @@ const WelcomeInfo = ({ t }) => (
     <div className='flex-auto pr3 lh-copy mid-gray'>
       <Box>
         <h1 className='mt0 mb3 montserrat fw4 f4 charcoal'>{t('welcomeInfo.header')}</h1>
-        <Trans i18nKey='welcomeInfo.paragraph1'>
+        <Trans i18nKey='welcomeInfo.paragraph1' t={t}>
           <p className='f5'><a href='#/' className='link blue u b'>Check the status</a> of your node, it's Peer ID and connection info, the network traffic and the number of connected peers.</p>
         </Trans>
-        <Trans i18nKey='welcomeInfo.paragraph2'>
+        <Trans i18nKey='welcomeInfo.paragraph2' t={t}>
           <p className='f5'>Easily <a href='#/files' className='link blue b'>manage files</a> in your IPFS repo. You can drag and drop to add files, move and rename them, delete, share or download them.</p>
         </Trans>
-        <Trans i18nKey='welcomeInfo.paragraph3'>
+        <Trans i18nKey='welcomeInfo.paragraph3' t={t}>
           <p className='f5'>You can <a href='#/explore' className='link blue b'>explore IPLD data</a> that underpins how IPFS works.</p>
         </Trans>
-        <Trans i18nKey='welcomeInfo.paragraph4'>
+        <Trans i18nKey='welcomeInfo.paragraph4' t={t}>
           <p className='f5'>See all of your <a href='#/peers' className='link blue b'>connected peers</a>, geolocated by their IP address.</p>
         </Trans>
-        <Trans i18nKey='welcomeInfo.paragraph5'>
+        <Trans i18nKey='welcomeInfo.paragraph5' t={t}>
           <p className='mb4 f5'><a href='#/settings' className='link blue b'>Review the settings</a> for your IPFS node, and update them to better suit your needs.</p>
         </Trans>
-        <Trans i18nKey='welcomeInfo.paragraph6'>
+        <Trans i18nKey='welcomeInfo.paragraph6' t={t}>
           <p className='mb0 f5'>If you want to help push the Web UI forward, <a href='https://github.com/ipfs-shipyard/ipfs-webui' className='link blue'>check out its code</a> or <a href='https://github.com/ipfs-shipyard/ipfs-webui/issues' className='link blue'>report a bug</a>!</p>
         </Trans>
       </Box>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -37,6 +37,8 @@ i18n
   .use(LanguageDetector)
   .init({
     ns: ['app', 'welcome', 'status', 'files', 'explore', 'peers', 'settings', 'notify'],
+    defaultNS: 'app',
+    fallbackNS: 'app',
     fallbackLng: {
       'zh-Hans': ['zh-CN', 'en'],
       'zh-Hant': ['zh-TW', 'en'],

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -46,7 +46,7 @@ export const statusTour = {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step3.title')}</h2>
         <p className='tl f6'>{t('tour.step3.paragraph1')}</p>
-        <Trans i18nKey='tour.step3.paragraph2'>
+        <Trans i18nKey='tour.step3.paragraph2' t={t}>
           <p className='tl f6'>Click on <code>Advanced</code> to see more info such as the gateway URL and addresses.</p>
         </Trans>
       </div>,
@@ -87,7 +87,7 @@ export const filesTour = {
     {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step1.title')}</h2>
-        <Trans i18nKey='tour.step1.paragraph1'>
+        <Trans i18nKey='tour.step1.paragraph1' t={t}>
           <p className='tl f6'>
             This is where the files on your <a className='teal link' href='https://docs.ipfs.io/guides/concepts/mfs/' rel='noopener noreferrer' target='_blank'>
             Mutable File System (MFS)</a> live. You can add files or folders and manage them from this page.
@@ -111,7 +111,7 @@ export const filesTour = {
         <h2 className='f3 fw4'>{t('tour.step3.title')}</h2>
         <p className='tl f6'>{t('tour.step3.paragraph1')}</p>
         <p className='tl f6'>{t('tour.step3.paragraph2')}</p>
-        <Trans i18nKey='tour.step3.paragraph3'>
+        <Trans i18nKey='tour.step3.paragraph3' t={t}>
           <p className='tl f6'>
             If you want to add something that is already on IPFS, you can import it to your MFS by passing its <a className='teal link' href='https://docs.ipfs.io/guides/concepts/cid/' rel='noopener noreferrer' target='_blank'>Content
             Identifier (CID)</a>.
@@ -196,7 +196,7 @@ export const settingsTour = {
     {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step2.title')}</h2>
-        <Trans i18nKey='tour.step2.paragraph1'>
+        <Trans i18nKey='tour.step2.paragraph1' t={t}>
           <p className='tl f6'>You can change the language of the Web UI.
           If your preferred language isn't available, head over our project page in <a className='teal link' href='https://www.transifex.com/ipfs/ipfs-webui/translate/' rel='noopener noreferrer' target='_blank'>Transifex</a> to help us translate!
           </p>

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -148,7 +148,7 @@ const SettingsInfo = ({ t, isIpfsConnected, isConfigBlocked, hasExternalChanges,
   } else if (hasExternalChanges) {
     return (
       <p className='ma0 lh-copy red f5 mw7'>
-        <Trans i18nKey='settingsHaveChanged'>
+        <Trans i18nKey='settingsHaveChanged' t={t}>
           The settings have changed, please click <strong>Reset</strong> to update the editor contents
         </Trans>
       </p>

--- a/src/status/BandwidthStatsDisabled.js
+++ b/src/status/BandwidthStatsDisabled.js
@@ -9,7 +9,7 @@ const StatusNotConnected = ({ t }) => {
       <h2 className='ttu yellow tracked f6 fw4 aqua mt0 mb4'>{t('bandwidthStats')}</h2>
 
       <p className='mw6 mr2 lh-copy charcoal f6'>
-        <Trans i18nKey='bandwidthStatsDisabled'>
+        <Trans i18nKey='bandwidthStatsDisabled' t={t}>
           You have the bandwidth metrics disabled. You can enable them by typing the command bellow
           or changing the key <code>Swarm.DisableBandwidthMetrics</code> to <code>false</code> on
           <a className='link blue' href='#/settings'>Settings</a>. Then, you need to restart the IPFS

--- a/src/status/StatusConnected.js
+++ b/src/status/StatusConnected.js
@@ -3,17 +3,17 @@ import { withTranslation, Trans } from 'react-i18next'
 import { connect } from 'redux-bundler-react'
 import filesize from 'filesize'
 
-export const StatusConnected = ({ peersCount, repoSize }) => {
+export const StatusConnected = ({ t, peersCount, repoSize }) => {
   const humanRepoSize = filesize(repoSize || 0, { round: 1 })
   return (
     <header>
       <h1 className='montserrat fw2 f3 charcoal ma0 pt0 pb2'>
-        <Trans i18nKey='StatusConnected.header1'>Connected to IPFS</Trans>
+        <Trans i18nKey='StatusConnected.header1' t={t}>Connected to IPFS</Trans>
       </h1>
       <p className='montserrat fw4 f5 ma0 pb3 lh-copy'>
         <span className='db dib-ns'>
           <Trans
-            i18nKey='StatusConnected.paragraph1'
+            i18nKey='StatusConnected.paragraph1' t={t}
             defaults='Hosting <0>{repoSize} of files</0>'
             values={{ repoSize: humanRepoSize }}
             components={[<a className='link blue' href='#/files'>?</a>]}
@@ -22,7 +22,7 @@ export const StatusConnected = ({ peersCount, repoSize }) => {
         <span className='dn di-ns gray'> — </span>
         <span className='db mt1 mt0-ns dib-ns'>
           <Trans
-            i18nKey='StatusConnected.paragraph2'
+            i18nKey='StatusConnected.paragraph2' t={t}
             defaults='Discovered <0>{peersCount} peers</0>'
             values={{ peersCount: peersCount.toString() }}
             components={[<a className='link blue' href='#/peers'>?</a>]}

--- a/src/status/StatusNotConnected.js
+++ b/src/status/StatusNotConnected.js
@@ -2,15 +2,15 @@ import React from 'react'
 import { withTranslation, Trans } from 'react-i18next'
 import Shell from '../components/shell/Shell'
 
-const StatusNotConnected = () => {
+const StatusNotConnected = ({ t }) => {
   return (
     <header>
       <h1 className='montserrat fw2 f3 yellow ma0 lh-title'>
-        <Trans i18nKey='StatusNotConnected.header1'>
+        <Trans i18nKey='StatusNotConnected.header1' t={t}>
           Failed to connect to the API
         </Trans>
       </h1>
-      <Trans i18nKey='StatusNotConnected.paragraph1'>
+      <Trans i18nKey='StatusNotConnected.paragraph1' t={t}>
         <p className='mv3 lh-copy sans-serif'>Start an IPFS daemon in a terminal:</p>
       </Trans>
       <Shell className='mw6'>
@@ -18,7 +18,7 @@ const StatusNotConnected = () => {
         <code className='db'>Initializing daemon...</code>
         <code className='db'>API server listening on /ip4/127.0.0.1/tcp/5001</code>
       </Shell>
-      <Trans i18nKey='StatusNotConnected.paragraph2'>
+      <Trans i18nKey='StatusNotConnected.paragraph2' t={t}>
         <p className='mt3 lh-copy sans-serif'>For more info on how to get started with IPFS you can <a className='link blue' href='https://docs.ipfs.io/introduction/usage/'>read the guide</a>.</p>
       </Trans>
     </header>

--- a/src/welcome/WelcomePage.js
+++ b/src/welcome/WelcomePage.js
@@ -25,7 +25,7 @@ const WelcomePage = ({ t, doUpdateIpfsApiAddress, apiUrl, ipfsInitFailed, ipfsCo
           <Box>
             <ConnectionStatus connected={ipfsConnected} sameOrigin={isSameOrigin} t={t} />
             <h1 className='montserrat fw2 navy mb0 mt5 f3 yellow'>{t('configureApiPort.header')}</h1>
-            <Trans i18nKey='configureApiPort.paragraph1'>
+            <Trans i18nKey='configureApiPort.paragraph1' t={t}>
               <p>If your IPFS node is configured with a <a className='link blue' href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#addresses' target='_blank' rel='noopener noreferrer'>custom API address</a>, please set it here</p>
             </Trans>
             <ApiAddressForm
@@ -47,10 +47,10 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
     return (
       <div>
         <h1 className='montserrat fw2 navy ma0 f3 green'>{t('connected.header')}</h1>
-        <Trans i18nKey='connected.paragraph1'>
+        <Trans i18nKey='connected.paragraph1' t={t}>
           <p>Now, it's time for you to explore your node. Head to <a className='link blue' href='#/files/'>Files page</a> to manage and share your files, or explore the <a className='link blue' href='https://www.youtube.com/watch?v=Bqs_LzBjQyk'>Merkle Forest</a> of peer-hosted hash-linked data via <a className='link blue' href='#/explore'>IPLD explorer</a>.</p>
         </Trans>
-        <Trans i18nKey='connected.paragraph2'>
+        <Trans i18nKey='connected.paragraph2' t={t}>
           <p>You can always come back to this address to change the IPFS node you're connected to.</p>
         </Trans>
       </div>
@@ -64,12 +64,12 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
   return (
     <div>
       <h1 className='montserrat fw2 navy ma0 f3 yellow'>{t('notConnected.header')}</h1>
-      <Trans i18nKey='notConnected.paragraph1'>
+      <Trans i18nKey='notConnected.paragraph1' t={t}>
         <p>Failed to connect to the API.</p>
       </Trans>
       { !sameOrigin && (
         <div>
-          <Trans i18nKey='notConnected.paragraph2'>
+          <Trans i18nKey='notConnected.paragraph2' t={t}>
             <p>Make sure you <a className='link blue' href='https://github.com/ipfs-shipyard/ipfs-webui#configure-ipfs-api-cors-headers'>configure your IPFS API</a> to allow cross-origin (CORS) requests, running the commands below:</p>
           </Trans>
           <Shell title="Unix & MacOS">
@@ -86,7 +86,7 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
           </Shell>
         </div>
       )}
-      <Trans i18nKey='notConnected.paragraph3'>
+      <Trans i18nKey='notConnected.paragraph3' t={t}>
         <p>Then, start/restart the IPFS daemon in a terminal:</p>
       </Trans>
       <Shell>
@@ -94,7 +94,7 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
         <code className='db'>Initializing daemon...</code>
         <code className='db'>API server listening on /ip4/127.0.0.1/tcp/5001</code>
       </Shell>
-      <Trans i18nKey='notConnected.paragraph4'>
+      <Trans i18nKey='notConnected.paragraph4' t={t}>
         <p>For more info on how to get started with IPFS you can <a className='link blue' href='https://docs.ipfs.io/introduction/usage/'>read the guide</a>.</p>
       </Trans>
     </div>


### PR DESCRIPTION
This PR fixes remaining issues with translations:

- fix(i18n): explicit t={t} in <Trans tags
  > Perhaps there is more elegant way to do this,
  > but by explicitly passing t we ensure everything works, no matter
  > if page is a separate module or if translations did not load yet.
  > Closes #1370
- fix(i18n): paragraoh2 → paragraph2
- fix(i18n): use app.json for fallback
  > default was translation.json, which does not exist, and always failed
  > closes #1395