### PR TITLE
fix: bootstrapPeers can be null

### DIFF
--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -64,7 +64,7 @@ export default function (opts) {
       const connection = parseConnection(peer.addr)
       const address = peer.addr.toString()
       const latency = parseLatency(peer.latency)
-      const notes = parseNotes(peer, bootstrapPeers)
+      const notes = bootstrapPeers ? parseNotes(peer, bootstrapPeers) : null
       const { isPrivate, isNearby } = isPrivateAndNearby(peer.addr, identity)
 
       return {


### PR DESCRIPTION
In the `Peers` page, I got this error:
![Screen Shot 2020-06-05 at 01 33 18](https://user-images.githubusercontent.com/13605410/83825304-39705a80-a6d9-11ea-81b5-3e369c4ca8b8.png)

Sometimes, `bootstrapPeers` can be null so we should test it.
I have this error when I run an Go embedded Ipfs node on mobile.

Signed-off-by: remi <remi@berty.tech>