### PR TITLE
fix(ci): increase timeout for E2E Peers screen tests

### DIFF
--- a/test/e2e/peers.test.js
+++ b/test/e2e/peers.test.js
@@ -6,6 +6,8 @@ describe('Peers screen', () => {
   let ipfsd
   let peeraddr
   beforeAll(async () => {
+    // bump timeouts
+    jest.setTimeout(30000)
     // spawn an ephemeral local node for manual swarm connect test
     ipfsd = await createController({ type: 'go', test: true, disposable: true })
     const { addresses } = await ipfsd.api.id()
@@ -24,7 +26,6 @@ describe('Peers screen', () => {
   })
 
   it('should confirm connection after "Add connection" ', async () => {
-    jest.setTimeout(15000)
     // enter multiaddr of a disposable local node spawned for this test
     await page.type('div[role="dialog"] input[type="text"]', peeraddr)
     // hit Enter

--- a/test/e2e/setup/test-environment.js
+++ b/test/e2e/setup/test-environment.js
@@ -14,6 +14,7 @@ class WebuiTestEnvironment extends PuppeteerEnvironment {
     const { ipfs, webuiUrl, page } = this.global
 
     // point WebUI at the HTTP API URL
+    await page.setViewport({ width: 1366, height: 768 })
     await page.goto(webuiUrl)
     const { apiHost, apiPort } = ipfs
     const apiMultiaddr = `/ip4/${apiHost}/tcp/${apiPort}`


### PR DESCRIPTION
This PR bumps timeout in E2E tests of Peers screen to 30s and closes #1507