### PR TITLE
fix(ci): more robust e2e

### DIFF
--- a/test/e2e/explore.test.js
+++ b/test/e2e/explore.test.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 
 describe('Explore screen', () => {
   beforeAll(async () => {
-    await page.goto(webuiUrl + '#/explore')
+    await page.goto(webuiUrl + '#/explore', { waitUntil: 'networkidle0' })
   })
 
   it('should have Project Apollo Archive as one of examples', async () => {
@@ -21,7 +21,8 @@ describe('Explore screen', () => {
     await expect(result.hash).toStrictEqual(cid)
 
     // open inspector
-    await page.goto(webuiUrl + `#/explore/${cid}`)
+    await page.goto(webuiUrl + `#/explore/${cid}`, { waitUntil: 'networkidle0' })
+    await page.waitForSelector(`a[href="#/explore/${cid}"]`)
     // expect node type
     await expect(page).toMatch('DAG Node')
     // expect cid details

--- a/test/e2e/files.test.js
+++ b/test/e2e/files.test.js
@@ -4,7 +4,7 @@ const { fixtureData } = require('./fixtures')
 
 describe('Files screen', () => {
   beforeAll(async () => {
-    await page.goto(webuiUrl + '#/files')
+    await page.goto(webuiUrl + '#/files', { waitUntil: 'networkidle0' })
   })
 
   const button = 'button[id="import-button"]'

--- a/test/e2e/navigation.test.js
+++ b/test/e2e/navigation.test.js
@@ -2,36 +2,46 @@
 
 describe('Navigation menu', () => {
   beforeAll(async () => {
-    await page.goto(webuiUrl)
+    await page.goto(webuiUrl + '#/blank', { waitUntil: 'networkidle0' })
   })
 
   it('should work for Status page', async () => {
+    const link = 'a[href="#/"]'
+    await page.waitForSelector(link)
     await expect(page).toMatch('Status')
-    await page.click('a[href="#/"]')
+    await page.click(link)
     await waitForTitle('Status - IPFS')
   })
 
   it('should work for Files page', async () => {
+    const link = 'a[href="#/files"]'
+    await page.waitForSelector(link)
     await expect(page).toMatch('Files')
-    await page.click('a[href="#/files"]')
+    await page.click(link)
     await waitForTitle('/ - Files - IPFS')
   })
 
   it('should work for Explore page', async () => {
+    const link = 'a[href="#/explore"]'
+    await page.waitForSelector(link)
     await expect(page).toMatch('Explore')
-    await page.click('a[href="#/explore"]')
+    await page.click(link)
     await waitForTitle('Explore - IPLD')
   })
 
   it('should work for Peers page', async () => {
+    const link = 'a[href="#/peers"]'
+    await page.waitForSelector(link)
     await expect(page).toMatch('Peers')
-    await page.click('a[href="#/peers"]')
+    await page.click(link)
     await waitForTitle('Peers - IPFS')
   })
 
   it('should work for Settings page', async () => {
+    const link = 'a[href="#/settings"]'
+    await page.waitForSelector(link)
     await expect(page).toMatch('Settings')
-    await page.click('a[href="#/settings"]')
+    await page.click(link)
     await waitForTitle('Settings - IPFS')
   })
 })

--- a/test/e2e/peers.test.js
+++ b/test/e2e/peers.test.js
@@ -1,4 +1,4 @@
-/* global webuiUrl, jest, ipfs page, describe, it, expect, beforeAll, afterAll */
+/* global webuiUrl, ipfs page, describe, it, expect, beforeAll, afterAll */
 
 const { createController } = require('ipfsd-ctl')
 
@@ -6,22 +6,20 @@ describe('Peers screen', () => {
   let ipfsd
   let peeraddr
   beforeAll(async () => {
-    // bump timeouts
-    jest.setTimeout(30000)
     // spawn an ephemeral local node for manual swarm connect test
     ipfsd = await createController({ type: 'go', test: true, disposable: true })
     const { addresses } = await ipfsd.api.id()
     peeraddr = addresses.find((ma) => ma.toString().startsWith('/ip4/127.0.0.1')).toString()
     // connect to peer to have something  in the peer table
     await ipfs.swarm.connect(peeraddr)
-    await page.goto(webuiUrl + '#/peers')
-    await page.reload()
+    await page.goto(webuiUrl + '#/peers', { waitUntil: 'networkidle0' })
   })
 
   it('should have a clickable "Add connection" button', async () => {
     const addConnection = 'Add connection'
     await expect(page).toMatch(addConnection)
     await expect(page).toClick('button', { text: addConnection })
+    await page.waitForSelector('div[role="dialog"]')
     await expect(page).toMatch('Insert the peer address you want to connect to')
   })
 

--- a/test/e2e/settings.test.js
+++ b/test/e2e/settings.test.js
@@ -2,7 +2,7 @@
 
 describe('Settings screen', () => {
   beforeAll(async () => {
-    await page.goto(webuiUrl + '#/settings')
+    await page.goto(webuiUrl + '#/settings', { waitUntil: 'networkidle0' })
   })
 
   it('should show config of IPFS node', async () => {

--- a/test/e2e/setup/global-after-env.js
+++ b/test/e2e/setup/global-after-env.js
@@ -1,3 +1,6 @@
-require('expect-puppeteer')
-// wait for 30s before failing a test
-jest.setTimeout(30 * 1000)
+const expect = require('expect-puppeteer')
+
+// increase timeouts for CI
+const timeout = 30 * 1000
+jest.setTimeout(timeout)
+expect.setDefaultOptions({ timeout })

--- a/test/e2e/setup/test-environment.js
+++ b/test/e2e/setup/test-environment.js
@@ -2,6 +2,8 @@
 const PuppeteerEnvironment = require('jest-environment-puppeteer')
 const expect = require('expect-puppeteer')
 
+expect.setDefaultOptions({ timeout: 30 * 1000 })
+
 class WebuiTestEnvironment extends PuppeteerEnvironment {
   async setup () {
     await super.setup()
@@ -9,7 +11,7 @@ class WebuiTestEnvironment extends PuppeteerEnvironment {
     // define globals that should be available in tests
     this.global.ipfs = global.__IPFS__
     this.global.webuiUrl = global.__WEBUI_URL__
-    this.global.waitForTitle = title => page.waitForFunction(`document.title === '${title}'`, { timeout: 8000 })
+    this.global.waitForTitle = title => page.waitForFunction(`document.title === '${title}'`)
 
     const { ipfs, webuiUrl, page } = this.global
 
@@ -27,7 +29,7 @@ class WebuiTestEnvironment extends PuppeteerEnvironment {
     // open Status page, confirm working connection to API
     await page.goto(webuiUrl + '#/')
     const { id } = await ipfs.id()
-    await expect(page).toMatch(id, { timeout: 30000 }) // initial load can be slow on CI
+    await expect(page).toMatch(id)
   }
 }
 

--- a/test/e2e/status.test.js
+++ b/test/e2e/status.test.js
@@ -2,7 +2,7 @@
 
 describe('Status page', () => {
   beforeAll(async () => {
-    await page.goto(webuiUrl)
+    await page.goto(webuiUrl, { waitUntil: 'networkidle0' })
   })
 
   it('should have Status menu item', async () => {


### PR DESCRIPTION
This PR takes #1518 even further: ensures we wait as long as needed for a full page load,  all necessary DOM elements, and set globaltimeout of 30s for jest and expect libs used in e2e tests.

If CI is green, I am merging this so js-ipfs and go-ipfs take advantage of this.