### PR TITLE
chore: update In-App CORS instructions to match README

### DIFF
--- a/src/welcome/WelcomePage.js
+++ b/src/welcome/WelcomePage.js
@@ -57,7 +57,7 @@ const ConnectionStatus = ({ t, connected, sameOrigin }) => {
     )
   }
 
-  const defaultDomains = ['http://127.0.0.1:5001', 'https://webui.ipfs.io']
+  const defaultDomains = ['http://localhost:3000', 'http://127.0.0.1:5001', 'https://webui.ipfs.io']
   const origin = window.location.origin
   const addOrigin = defaultDomains.indexOf(origin) === -1
 


### PR DESCRIPTION
Currently, the "API Not Connected" Error does not give the complete list of origins that need to be added to the IPFS settings according to the README.

This PR brings the In-App CORS instructions up to par with the README.

Haven't tested.