### PR TITLE
Remove self-ref files page link in "no files" screen

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -68,7 +68,7 @@
   "welcomeInfo": {
     "header": "Welcome to the IPFS Web UI",
     "paragraph1": "<0><0>Check the status</0> of your node, its Peer ID and connection info, the network traffic and the number of connected peers.</0>",
-    "paragraph2": "<0>Easily <1>manage files</1> in your IPFS repo. You can drag and drop to add files, and you can move, rename, delete, share or download them.</0>",
+    "paragraph2": "<0>Easily manage files in your IPFS repo. Drag and drop here to add files, and you can move, rename, delete, share or download them.</0>",
     "paragraph3": "<0>You can <1>explore IPLD data</1> that underpins how IPFS works.</0>",
     "paragraph4": "<0>See all of your <1>connected peers</1>, geolocated by their IP address.</0>",
     "paragraph5": "<0><0>Review the settings</0> for your IPFS node, and update them to better suit your needs.</0>",
@@ -120,7 +120,7 @@
     "inspect": "Inspect"
   },
   "previousFolder": "Go back to previous folder",
-  "fileLabel": "Select {type} {name} with size: {size}", 
+  "fileLabel": "Select {type} {name} with size: {size}",
   "hashUnavailable": "hash unavailable",
   "checkboxLabel": "View more options for {name}",
   "pins": "Pins",

--- a/public/locales/ko-KR/files.json
+++ b/public/locales/ko-KR/files.json
@@ -62,7 +62,7 @@
   "welcomeInfo": {
     "header": "Welcome to the IPFS Web UI",
     "paragraph1": "<0><0>Check the status</0> of your node, it's Peer ID and connection info, the network traffic and the number of connected peers.</0>",
-    "paragraph2": "<0>Easily <1>manage files</1> in your IPFS repo. You can drag and drop to add files, move and rename them, delete, share or download them.</0>",
+    "paragraph2": "<0>Easily manage files in your IPFS repo. Drag and drop here to add files, move and rename them, delete, share or download them.</0>",
     "paragraph3": "<0>You can <1>explore IPLD data</1> that underpins how IPFS works.</0>",
     "paragraph4": "<0>See all of your <1>connected peers</1>, geolocated by their IP address.</0>",
     "paragraph5": "<0><0>Review the settings</0> for your IPFS node, and update them to better suit your needs.</0>",

--- a/public/locales/sv/files.json
+++ b/public/locales/sv/files.json
@@ -62,7 +62,7 @@
   "welcomeInfo": {
     "header": "Välkommen till IPFS webb-gränssnitt",
     "paragraph1": "<0><0>Check the status</0> of your node, it's Peer ID and connection info, the network traffic and the number of connected peers.</0>",
-    "paragraph2": "<0>Easily <1>manage files</1> in your IPFS repo. You can drag and drop to add files, move and rename them, delete, share or download them.</0>",
+    "paragraph2": "<0>Easily manage files in your IPFS repo. Drag and drop here to add files, move and rename them, delete, share or download them.</0>",
     "paragraph3": "<0>You can <1>explore IPLD data</1> that underpins how IPFS works.</0>",
     "paragraph4": "<0>See all of your <1>connected peers</1>, geolocated by their IP address.</0>",
     "paragraph5": "<0><0>Review the settings</0> for your IPFS node, and update them to better suit your needs.</0>",

--- a/src/files/info-boxes/welcome-info/WelcomeInfo.js
+++ b/src/files/info-boxes/welcome-info/WelcomeInfo.js
@@ -9,10 +9,10 @@ const WelcomeInfo = ({ t }) => (
       <Box>
         <h1 className='mt0 mb3 montserrat fw4 f4 charcoal'>{t('welcomeInfo.header')}</h1>
         <Trans i18nKey='welcomeInfo.paragraph1' t={t}>
-          <p className='f5'><a href='#/' className='link blue u b'>Check the status</a> of your node, it's Peer ID and connection info, the network traffic and the number of connected peers.</p>
+          <p className='f5'><a href='#/' className='link blue u b'>Check the status</a> of your node, its Peer ID and connection info, the network traffic and the number of connected peers.</p>
         </Trans>
         <Trans i18nKey='welcomeInfo.paragraph2' t={t}>
-          <p className='f5'>Easily <a href='#/files' className='link blue b'>manage files</a> in your IPFS repo. You can drag and drop to add files, move and rename them, delete, share or download them.</p>
+          <p className='f5'>Easily manage files in your IPFS repo. Drag and drop here to add files, move and rename them, delete, share or download them.</p>
         </Trans>
         <Trans i18nKey='welcomeInfo.paragraph3' t={t}>
           <p className='f5'>You can <a href='#/explore' className='link blue b'>explore IPLD data</a> that underpins how IPFS works.</p>


### PR DESCRIPTION
- Removes the files screen's "manage files" link to itself when displaying no-files-here welcome text
- Changes "You can drag and drop ..." to "Drag and drop here ..."
- Fixes an it's/its typo

Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1530