### PR TITLE
add logic to build and publish a tarball on release

### DIFF
--- a/.github/workflows/publish_build.yml
+++ b/.github/workflows/publish_build.yml
@@ -21,7 +21,7 @@ jobs:
           tar -czf ipfs-webui.tar.gz build/*
 
       - name: Copy build-artifacts to Release
-        uses: skx/github-action-publish-binaries@master
+        uses: skx/github-action-publish-binaries@release-0.14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish_build.yml
+++ b/.github/workflows/publish_build.yml
@@ -1,0 +1,28 @@
+name: Publish Binaries
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2 
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm run build
+          tar -czf ipfs-webui.tar.gz build/*
+
+      - name: Copy build-artifacts to Release
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: "./ipfs-webui.tar.gz"


### PR DESCRIPTION
I wanted to consume this software downstream for a Docker image, but the build process is a bit heavy. 

This logic pushes a tarball to a release when published. 

You can see an example on my fork here: 
https://github.com/thelamer/ipfs-webui/releases/tag/v2.10.2
https://github.com/thelamer/ipfs-webui/runs/855791405?check_suite_focus=true

You don't need to setup anything on the repo, merging this will push tarballs for all subsequent releases made after merge. 

I understand the value of pushing stuff like this to IPFS but in the case of software ingestion from your repo, the whole world conventionally hits the latest release api on github and pulls in on new release tags. Having this build asset transparently built in Github greatly simplifies this process. 

Let me know if you have any questions. 