### PR TITLE
fix: responsive navbar on small devices

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,7 @@ export class App extends Component {
       <div className='sans-serif h-100' onClick={getNavHelper(this.props.doUpdateUrl)}>
         {/* Tinted overlay that appears when dragging and dropping an item */}
         { canDrop && isOver && <div className='w-100 h-100 top-0 left-0 absolute' style={{ background: 'rgba(99, 202, 210, 0.2)' }} /> }
-        <div className='flex flex-row-reverse-l flex-column-reverse' style={{ minHeight: '100vh' }}>
+        <div className='flex flex-row-reverse-l flex-column-reverse justify-end justify-start-l' style={{ minHeight: '100vh' }}>
           <div className='flex-auto-l'>
             <div className='flex items-center ph3 ph4-l' style={{ WebkitAppRegion: 'drag', height: 75, background: '#F0F6FA', paddingTop: '20px', paddingBottom: '15px' }}>
               <div className='joyride-app-explore' style={{ width: 560 }}>

--- a/test/e2e/navigation.test.js
+++ b/test/e2e/navigation.test.js
@@ -1,5 +1,15 @@
 /* global webuiUrl, waitForTitle, page, describe, it, expect, beforeAll */
 
+const scrollLinkContainer = async () => {
+  const linkContainer = '[role="menubar"]'
+  await page.waitForSelector(linkContainer)
+  await page.evaluate(selector => {
+    const scrollableSection = document.querySelector(selector)
+
+    scrollableSection.scrollLeft = scrollableSection.offsetWidth
+  }, linkContainer)
+}
+
 describe('Navigation menu', () => {
   beforeAll(async () => {
     await page.goto(webuiUrl + '#/blank', { waitUntil: 'networkidle0' })
@@ -25,6 +35,7 @@ describe('Navigation menu', () => {
     const link = 'a[href="#/explore"]'
     await page.waitForSelector(link)
     await expect(page).toMatch('Explore')
+    await scrollLinkContainer()
     await page.click(link)
     await waitForTitle('Explore - IPLD')
   })
@@ -33,6 +44,7 @@ describe('Navigation menu', () => {
     const link = 'a[href="#/peers"]'
     await page.waitForSelector(link)
     await expect(page).toMatch('Peers')
+    await scrollLinkContainer()
     await page.click(link)
     await waitForTitle('Peers - IPFS')
   })
@@ -41,6 +53,7 @@ describe('Navigation menu', () => {
     const link = 'a[href="#/settings"]'
     await page.waitForSelector(link)
     await expect(page).toMatch('Settings')
+    await scrollLinkContainer()
     await page.click(link)
     await waitForTitle('Settings - IPFS')
   })


### PR DESCRIPTION
Pipeline was failing sometimes https://app.circleci.com/pipelines/github/ipfs-shipyard/ipfs-webui/301/workflows/7d739c8e-9f97-4ad9-a870-fb889442f7d9/jobs/4074 saying that "Explore" link was not clickable. 

I think it was because the window used by the CI was too small, hiding the element.

Hopefully this PR fixes it, will rekick the pipeline a couple of times to make sure 🙏 