### PR TITLE
fix: make explore page 'view on gateway' point to gateway

### DIFF
--- a/src/explore/ExploreContainer.js
+++ b/src/explore/ExploreContainer.js
@@ -5,17 +5,12 @@ import withTour from '../components/tour/withTour'
 
 const ExploreContainer = ({
   toursEnabled,
-  handleJoyrideCallback,
-  gatewayUrl
+  handleJoyrideCallback
 }) => (
-  <ExplorePage
-    runTour={toursEnabled}
-    joyrideCallback={handleJoyrideCallback}
-    gatewayUrl={gatewayUrl} />
+  <ExplorePage runTour={toursEnabled} joyrideCallback={handleJoyrideCallback} />
 )
 
 export default connect(
   'selectToursEnabled',
-  'selectGatewayUrl',
   withTour(ExploreContainer)
 )


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1490


## Notes

Removing the `gatewayUrl` prop just allows for `ipld-explorer-component` to use the default one (`https://ipfs.io`)