### PR TITLE
bug: tweak map height for sub-940px-high windows

### DIFF
--- a/src/peers/WorldMap/WorldMap.js
+++ b/src/peers/WorldMap/WorldMap.js
@@ -35,7 +35,7 @@ const calculateWidth = (windowWidth) => {
 }
 
 const calculateHeight = (width) => {
-  if (width > 1000) {
+  if (width > 960) {
     return width * 0.273
   }
 

--- a/src/peers/WorldMap/WorldMap.js
+++ b/src/peers/WorldMap/WorldMap.js
@@ -36,6 +36,9 @@ const calculateWidth = (windowWidth) => {
 
 const calculateHeight = (width) => {
   if (width > 960) {
+    if (window.innerHeight < 940) {
+      return (window.innerHeight - 180) * 0.6
+    }
     return width * 0.273
   }
 


### PR DESCRIPTION
This PR makes the following changes to how the peers map is displayed:

- Updates effective breakpoint in `WorldMap.js` to 960px, to match the tachyons breakpoint that forces nav menu to top of screen (NOTE this is slightly unrelated to original issue, but tidies the landscape for thinking about this)
- Adds a "height breakpoint" of `window.innerHeight < 940` to address concerns raised in https://github.com/ipfs-shipyard/ipfs-webui/issues/1561 for users with small laptops
     - If window height is less than 940px, map height is 0.6 * window height, minus 180px allowance for furniture (search bar and "Add connection" button)

Note that to make this totally seamless for everyone, all the time, we'd really need to pull the peers page apart entirely and do something much more clever with truncating the map display for some window aspect ratios; I'd like to save that for a more substantial rework of the UI as a whole. However, this does keep the user from losing the peers list on smaller windows with non-extreme aspect ratios.

**Screenshots (before on left, after on right)**

1280 x 800, smallest current MacBook screen resolution:
![image](https://user-images.githubusercontent.com/1507828/88709272-21fa9000-d0d2-11ea-9179-b3e0da58a4c2.png)

965 x 570, just barely wider than the 960px nav menu breakpoint:
![image](https://user-images.githubusercontent.com/1507828/88709771-db596580-d0d2-11ea-90c4-c8ddb8b3a888.png)

Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1561