### PR TITLE
fix: update Import button name

### DIFF
--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -76,7 +76,7 @@
   },
   "filesListLabel": "Files list",
   "filesList": {
-    "noFiles": "<0>No files in this directory. Click the “Add” button to add some.</0>"
+    "noFiles": "<0>No files in this directory. Click the “Import” button to add some.</0>"
   },
   "filesImportStatus": {
     "imported": "{count, plural, one {Imported 1 item} other {Imported {count} items}}",


### PR DESCRIPTION
The label does not match UI (button was renamed to "Import" a while ago):

> ![2020-07-28--21-48-53](https://user-images.githubusercontent.com/157609/88714144-a6720080-d11c-11ea-967e-cb9cbab2b62f.png)
