### PR TITLE
chore: update ipfs-geoip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14394,31 +14394,53 @@
       "integrity": "sha512-2gnYRkPbgldiXSjdfbMUN2sGLr9DuVaj6nL2aAQvAE5buEj9mhUEkqQ8er6w6uqzlyFWnpSdh5IsiYu4cN4dRw=="
     },
     "ipfs-geoip": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-geoip/-/ipfs-geoip-4.1.0.tgz",
-      "integrity": "sha512-XREXUgeJvhw650Lcon8Iedk5k8MgqiPyMR309Ik3h7lSOFeQjpAJm7pq9SfQyBEiIOsiSbe+DiESYOnqeGmUwA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-geoip/-/ipfs-geoip-5.0.0.tgz",
+      "integrity": "sha512-ZmPeJ81xxg1BwfO8BLr1ZbAM+xbMQFueMgYRmDapBY/bl7dQNnVe9NJtGH2E88L/JBmhkRvjUoYsPoASgj7Erg==",
       "requires": {
+        "cids": "^1.0.0",
         "inet_ipv4": "^1.0.1",
-        "memoizee": "~0.4.14",
-        "multihashes": "~0.4.15"
+        "it-concat": "^1.0.0",
+        "memoizee": "~0.4.14"
       },
       "dependencies": {
+        "cids": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+          "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashes": "^3.0.1",
+            "uint8arrays": "^1.0.0"
+          }
+        },
         "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+          "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
           "requires": {
             "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "multicodec": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+          "integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+          "requires": {
+            "uint8arrays": "1.0.0",
+            "varint": "^5.0.0"
           }
         },
         "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+          "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
           "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.0.0",
             "varint": "^5.0.0"
           }
         }
@@ -23110,14 +23132,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-router-hash-link": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.0.0.tgz",
-      "integrity": "sha512-vAiiHUhPcT5NYwKutvbAgHR2HXoESkTyaeXQaW1cmVwZujhmHEfaXRh28uS52jQaja/S+Xrc0aFizfljY7rvAw==",
-      "requires": {
-        "prop-types": "^15.6.0"
-      }
-    },
     "react-scripts": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.4.1.tgz",
@@ -26666,7 +26680,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
       "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
-      "dev": true,
       "requires": {
         "multibase": "^3.0.0",
         "web-encoding": "^1.0.2"
@@ -26676,7 +26689,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
           "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
-          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "web-encoding": "^1.0.2"
@@ -27388,8 +27400,7 @@
     "web-encoding": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
-      "integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA==",
-      "dev": true
+      "integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
     },
     "webcrypto": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10161,17 +10161,6 @@
         "ext": "^1.1.2"
       }
     },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "escalade": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
@@ -10960,15 +10949,6 @@
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
-      }
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
       }
     },
     "event-iterator": {
@@ -14394,14 +14374,14 @@
       "integrity": "sha512-2gnYRkPbgldiXSjdfbMUN2sGLr9DuVaj6nL2aAQvAE5buEj9mhUEkqQ8er6w6uqzlyFWnpSdh5IsiYu4cN4dRw=="
     },
     "ipfs-geoip": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-geoip/-/ipfs-geoip-5.0.0.tgz",
-      "integrity": "sha512-ZmPeJ81xxg1BwfO8BLr1ZbAM+xbMQFueMgYRmDapBY/bl7dQNnVe9NJtGH2E88L/JBmhkRvjUoYsPoASgj7Erg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-geoip/-/ipfs-geoip-5.0.1.tgz",
+      "integrity": "sha512-GyOtzE85YQ/mH8bzUOiuQkATIULIfSJyeOFsosU/LAZgWkcmduu4C2r7Br36cG9erxa9z+jqgVoGxCYBY8bZpg==",
       "requires": {
         "cids": "^1.0.0",
         "inet_ipv4": "^1.0.1",
         "it-concat": "^1.0.0",
-        "memoizee": "~0.4.14"
+        "p-memoize": "^4.0.0"
       },
       "dependencies": {
         "cids": {
@@ -15822,11 +15802,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-pull-stream": {
       "version": "0.0.0",
@@ -18736,14 +18711,6 @@
         }
       }
     },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "requires": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
@@ -18897,21 +18864,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
       "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
       "dev": true
-    },
-    "memoizee": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
-      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.45",
-        "es6-weak-map": "^2.0.2",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.1",
-        "lru-queue": "0.1",
-        "next-tick": "1",
-        "timers-ext": "^0.1.5"
-      }
     },
     "memoizerific": {
       "version": "1.11.3",
@@ -19646,11 +19598,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-1.0.4.tgz",
       "integrity": "sha512-6fNIumJJUyP3rkB4FyVYCYpdW+PKUCaxRWRGLLf0kv/RKoG4mbTvInedA9x3zOyuOmOkGudKuAtPSI+dnhwj2g=="
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -26245,15 +26192,6 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
-      }
-    },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
       }
     },
     "timestamp-nano": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "internal-nav-helper": "^3.1.0",
     "ip": "^1.1.5",
     "ipfs-css": "^1.2.0",
-    "ipfs-geoip": "^5.0.0",
+    "ipfs-geoip": "^5.0.1",
     "ipfs-http-client": "^46.0.0",
     "ipfs-provider": "^1.0.0",
     "ipld-explorer-components": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "internal-nav-helper": "^3.1.0",
     "ip": "^1.1.5",
     "ipfs-css": "^1.2.0",
-    "ipfs-geoip": "^4.1.0",
+    "ipfs-geoip": "^5.0.0",
     "ipfs-http-client": "^46.0.0",
     "ipfs-provider": "^1.0.0",
     "ipld-explorer-components": "1.6.0",

--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -213,7 +213,7 @@ class PeerLocationResolver {
   constructor (opts) {
     this.geoipCache = getConfiguredCache({
       name: 'geoipCache',
-      version: 1,
+      version: 2,
       maxAge: ms.weeks(1),
       ...opts.cache
     })


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1603.
- Bumps `ipfs-geiop` to v5.0.1
- Bumps `geoipCache` in `peer-locations.js` to avoid cache discrepancies (United States vs USA) as described in https://github.com/ipfs-shipyard/ipfs-webui/issues/1603#issuecomment-684784369 

See screenshot:
![image](https://user-images.githubusercontent.com/1507828/91888394-77820980-ec49-11ea-8a01-a363cbb05229.png)