### PR TITLE
chore(ci): use npm ci

### DIFF
--- a/.github/workflows/publish_build.yml
+++ b/.github/workflows/publish_build.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Install and Build 🔧
         run: |
-          npm install
+          npm ci
           npm run build
           tar -czf ipfs-webui.tar.gz build/*
 


### PR DESCRIPTION
This is a tiny fix for https://github.com/ipfs-shipyard/ipfs-webui/pull/1543 to produce deterministic build based on `package-lock.json`

@thelamer @olizilla  does this sound good, or am I missing some context behind going with `npm install`?