### PR TITLE
fix: fast pin.ls check

### DIFF
--- a/src/bundles/ipfs-provider.js
+++ b/src/bundles/ipfs-provider.js
@@ -284,7 +284,7 @@ const bundle = {
 
   doCheckIfPinned: (cid) => async () => {
     try {
-      const value = await first(ipfs.pin.ls({ paths: [cid] }))
+      const value = await first(ipfs.pin.ls({ paths: [cid], type: 'recursive' }))
       return !!value
     } catch (_) { return false }
   }


### PR DESCRIPTION
Closes #https://github.com/ipfs-shipyard/ipfs-webui/issues/1618