### PR TITLE
Have CI publish to the Collab Cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
         environment:
           DOMAIN: webui.ipfs.io
           BUILD_DIR: build
+          CLUSTER_HOST: /dnsaddr/ipfs-websites.collab.ipfscluster.io
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
similar to https://github.com/ipfs/ipfs-docs/pull/195

When CI/CD runs and generates a CID, we need to pin that CID directly to the Websites (collab) cluster. Otherwise, when CircleCI's build finishes, the ipfs instance will dissapear and the CID will be irretrievable.