### PR TITLE
fix: restore download of a single folder

### DIFF
--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -45,17 +45,19 @@ export function normalizeFiles (files) {
  * @returns {Promise<FileDownload>}
  */
 async function downloadSingle (file, gatewayUrl, apiUrl) {
-  let url, filename
+  let url, filename, method
 
   if (file.type === 'directory') {
     url = `${apiUrl}/api/v0/get?arg=${file.cid}&archive=true&compress=true`
     filename = `${file.name}.tar.gz`
+    method = 'POST' // API is POST-only
   } else {
     url = `${gatewayUrl}/ipfs/${file.cid}`
     filename = file.name
+    method = 'GET'
   }
 
-  return { url, filename, method: 'GET' }
+  return { url, filename, method }
 }
 
 /**
@@ -96,7 +98,7 @@ async function downloadMultiple (files, apiUrl, ipfs) {
   return {
     url: `${apiUrl}/api/v0/get?arg=${cid}&archive=true&compress=true`,
     filename: `download_${cid}.tar.gz`,
-    method: 'POST'
+    method: 'POST' // API is POST-only
   }
 }
 


### PR DESCRIPTION
This PR restores _Download_ feature when a single folder is selected.
https://github.com/ipfs-shipyard/ipfs-webui/issues/1576  missed one edge case, this fixes that + adds comments why we need POST.