### PR TITLE
fix(i18n): sync app.json and notify.json

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,11 +1,18 @@
 [main]
 host = https://www.transifex.com
-lang_map = zh_CN: zh-CN, zh_HK: zh-HK, zh_TW: zh-TW, ko_KR: ko-KR, pt_PT: pt-PT, pt_BR: pt-BR, ja_JP: ja-JP
+lang_map = zh_CN: zh-CN, zh_HK: zh-HK, zh_TW: zh-TW, ko_KR: ko-KR, pt_PT: pt-PT, pt_BR: pt-BR, ja_JP: ja-JP, hi_IN: hi-IN, he_IL: he-IL, fa_IR: fa-IR, bn_IN: bn-IN
 
 [ipfs-webui.app-json]
 file_filter = public/locales/<lang>/app.json
 minimum_perc = 75
 source_file = public/locales/en/app.json
+source_lang = en
+type = KEYVALUEJSON
+
+[ipfs-webui.notify-json]
+file_filter = public/locales/<lang>/notify.json
+minimum_perc = 75
+source_file = public/locales/en/notify.json
 source_lang = en
 type = KEYVALUEJSON
 

--- a/.tx/config
+++ b/.tx/config
@@ -2,6 +2,13 @@
 host = https://www.transifex.com
 lang_map = zh_CN: zh-CN, zh_HK: zh-HK, zh_TW: zh-TW, ko_KR: ko-KR, pt_PT: pt-PT, pt_BR: pt-BR, ja_JP: ja-JP
 
+[ipfs-webui.app-json]
+file_filter = public/locales/<lang>/app.json
+minimum_perc = 75
+source_file = public/locales/en/app.json
+source_lang = en
+type = KEYVALUEJSON
+
 [ipfs-webui.welcome-json]
 file_filter = public/locales/<lang>/welcome.json
 minimum_perc = 75


### PR DESCRIPTION
This ensures translations for `app.json` and `notify.json` will be fetched when `tx pull -a` is executed and translation is at least 75% complete.

Closes #1636