### PR TITLE
chore: update hint text in browse bar

### DIFF
--- a/src/files/explore-form/FilesExploreForm.js
+++ b/src/files/explore-form/FilesExploreForm.js
@@ -81,7 +81,7 @@ class FilesExploreForm extends React.Component {
       <div data-id='FilesExploreForm' className='sans-serif black-80 flex'>
         <div className='flex-auto'>
           <div className='relative'>
-            <input id='ipfs-path' className={`input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light ${this.inputClass}`} style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='QmHash/bafyhash' aria-describedby='ipfs-path-desc' onChange={this.onChange} onKeyDown={this.onKeyDown} value={this.state.path} />
+            <input id='ipfs-path' className={`input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light ${this.inputClass}`} style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='QmHash/bafyHash' aria-describedby='ipfs-path-desc' onChange={this.onChange} onKeyDown={this.onKeyDown} value={this.state.path} />
             <small id='ipfs-path-desc' className='o-0 absolute f6 black-60 db mb2'>Paste in a CID or IPFS path</small>
           </div>
         </div>

--- a/src/files/explore-form/FilesExploreForm.js
+++ b/src/files/explore-form/FilesExploreForm.js
@@ -81,7 +81,7 @@ class FilesExploreForm extends React.Component {
       <div data-id='FilesExploreForm' className='sans-serif black-80 flex'>
         <div className='flex-auto'>
           <div className='relative'>
-            <input id='ipfs-path' className={`input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light ${this.inputClass}`} style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='QmHash' aria-describedby='ipfs-path-desc' onChange={this.onChange} onKeyDown={this.onKeyDown} value={this.state.path} />
+            <input id='ipfs-path' className={`input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light ${this.inputClass}`} style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='QmHash/bafyhash' aria-describedby='ipfs-path-desc' onChange={this.onChange} onKeyDown={this.onKeyDown} value={this.state.path} />
             <small id='ipfs-path-desc' className='o-0 absolute f6 black-60 db mb2'>Paste in a CID or IPFS path</small>
           </div>
         </div>


### PR DESCRIPTION
As mentioned in https://github.com/ipfs-shipyard/ipfs-webui/issues/1636#issue-702818983:

> In the search bar on top "Qmhash" should be switched to "bafyHash" or "IPFS CID" or "CID"?

This PR adds a reference to `bafy` hashes as depicted below. Happy to haggle over the text.

![image](https://user-images.githubusercontent.com/1507828/93369674-f6ac3b80-f80c-11ea-9a20-6ed8d5a0ca6d.png)

