### PR TITLE
feat: add version info in nav and Status screen, tighten nav accordingly

### DIFF
--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -76,7 +76,8 @@
     "totalIn": "Total in",
     "totalOut": "Total out",
     "unknown": "Unknown",
-    "upSpeed": "Outgoing"
+    "upSpeed": "Outgoing",
+    "version": "Version"
   },
   "tour": {
     "back": "Back",

--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -76,8 +76,8 @@
     "totalIn": "Total in",
     "totalOut": "Total out",
     "unknown": "Unknown",
-    "upSpeed": "Outgoing",
-    "version": "Version"
+    "ui": "UI",
+    "upSpeed": "Outgoing"
   },
   "tour": {
     "back": "Back",

--- a/src/components/definition/Definition.js
+++ b/src/components/definition/Definition.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 export const Definition = ({ term, desc, advanced, termWidth }) => (
-  <div className='dt dt--fixed pt2 mw9 lh-copy'>
+  <div className='dt dt--fixed pt1 mw9 lh-copy'>
     <Term width={termWidth}>
       {term}
     </Term>

--- a/src/navigation/NavBar.css
+++ b/src/navigation/NavBar.css
@@ -4,7 +4,7 @@
 
 @media only screen and (min-width: 60em) {
   .navbar-container {
-    width: 9.75rem;
+    width: 9.25rem;
   }
   .navbar-item-active {
     border-left: 5px solid rgba(201, 210, 215, .4);
@@ -12,7 +12,7 @@
   }
 }
 
-@media only screen and (max-height: 790px) {
+@media only screen and (max-height: 640px) {
   .navbar-footer {
     display: none;
   }

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -76,7 +76,7 @@ export const NavBar = ({ t }) => {
       </div>
       <div className='dn db-l navbar-footer mb2 tc center f7 o-80 glow'>
         { webUiVersion && <div className='mb1'>
-          <a className='link white' href={webUiVersionUrl} target='_blank' rel='noopener noreferrer'>{t('app:terms.version')} {webUiVersion}</a>
+          <a className='link white' href={webUiVersionUrl} target='_blank' rel='noopener noreferrer'>{t('app:terms.ui')} v{webUiVersion}</a>
         </div> }
         { gitRevision && <div className='mb1'>
           <a className='link white' href={revisionUrl} target='_blank' rel='noopener noreferrer'>{t('app:nav.revision')} {gitRevision}</a>

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -55,6 +55,8 @@ export const NavBar = ({ t }) => {
   const bugsUrl = `${codeUrl}/issues`
   const gitRevision = process.env.REACT_APP_GIT_REV
   const revisionUrl = `${codeUrl}/commit/${gitRevision}`
+  const webUiVersion = process.env.REACT_APP_VERSION
+  const webUiVersionUrl = `${codeUrl}/releases/tag/v${webUiVersion}`
   return (
     <div className='h-100 fixed-l flex flex-column justify-between' style={{ overflowY: 'auto', width: 'inherit' }}>
       <div className='flex flex-column'>
@@ -73,6 +75,9 @@ export const NavBar = ({ t }) => {
         </div>
       </div>
       <div className='dn db-l navbar-footer mb3 tc center f7 o-80 glow'>
+        { webUiVersion && <div className='mb1'>
+          <a className='link white' href={webUiVersionUrl} target='_blank' rel='noopener noreferrer'>{t('app:terms.version')} {webUiVersion}</a>
+        </div> }
         { gitRevision && <div className='mb1'>
           <a className='link white' href={revisionUrl} target='_blank' rel='noopener noreferrer'>{t('app:nav.revision')} {gitRevision}</a>
         </div> }

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -61,8 +61,8 @@ export const NavBar = ({ t }) => {
     <div className='h-100 fixed-l flex flex-column justify-between' style={{ overflowY: 'auto', width: 'inherit' }}>
       <div className='flex flex-column'>
         <a href="#/welcome" role='menuitem' title={t('welcome:description')}>
-          <div className='pt3 pb1 pv3-l'>
-            <img className='center db-l dn' style={{ height: 94 }} src={ipfsLogoTextVert} alt='' />
+          <div className='pt3 pb1 pv2-l'>
+            <img className='center db-l dn pv1' style={{ height: 94 }} src={ipfsLogoTextVert} alt='' />
             <img className='center db dn-l' style={{ height: 70 }} src={ipfsLogoTextHoriz} alt='' />
           </div>
         </a>
@@ -74,7 +74,7 @@ export const NavBar = ({ t }) => {
           <NavLink to='/settings' icon={StrokeSettings}>{t('settings:title')}</NavLink>
         </div>
       </div>
-      <div className='dn db-l navbar-footer mb3 tc center f7 o-80 glow'>
+      <div className='dn db-l navbar-footer mb2 tc center f7 o-80 glow'>
         { webUiVersion && <div className='mb1'>
           <a className='link white' href={webUiVersionUrl} target='_blank' rel='noopener noreferrer'>{t('app:terms.version')} {webUiVersion}</a>
         </div> }

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -29,7 +29,7 @@ const NavLink = ({
   const anchorClass = classnames({
     'bg-white-10 navbar-item-active': active,
     'o-50 no-pointer-events': disabled
-  }, ['dib db-l pt2 pb3 pv3-l white no-underline f5 hover-bg-white-10 tc bb bw2 bw0-l b--navy'])
+  }, ['dib db-l pt2 pb3 pv2-l white no-underline f5 hover-bg-white-10 tc bb bw2 bw0-l b--navy'])
   const svgClass = classnames({
     'o-100': active,
     'o-50': !active
@@ -40,7 +40,7 @@ const NavLink = ({
     <a href={disabled ? null : href} className={anchorClass} role='menuitem' title={children}>
       <div className='db ph2 pv1'>
         <div className='db'>
-          <Svg width='50' role='presentation' className={svgClass} />
+          <Svg width='46' role='presentation' className={svgClass} />
         </div>
         <div className={`${active ? 'o-100' : 'o-50'} db f6 tc montserrat ttu fw1 `} style={{ whiteSpace: 'pre-wrap' }}>
           {children}
@@ -59,8 +59,8 @@ export const NavBar = ({ t }) => {
     <div className='h-100 fixed-l flex flex-column justify-between' style={{ overflowY: 'auto', width: 'inherit' }}>
       <div className='flex flex-column'>
         <a href="#/welcome" role='menuitem' title={t('welcome:description')}>
-          <div className='pt3 pb1 pv4-l'>
-            <img className='center db-l dn' style={{ height: 100 }} src={ipfsLogoTextVert} alt='' />
+          <div className='pt3 pb1 pv3-l'>
+            <img className='center db-l dn' style={{ height: 94 }} src={ipfsLogoTextVert} alt='' />
             <img className='center db dn-l' style={{ height: 70 }} src={ipfsLogoTextHoriz} alt='' />
           </div>
         </a>

--- a/src/status/NodeInfo.js
+++ b/src/status/NodeInfo.js
@@ -29,6 +29,7 @@ class NodeInfo extends React.Component {
       <DefinitionList>
         <Definition term={t('terms.peerId')} desc={this.getField(identity, 'id')} />
         <Definition term={t('terms.agent')} desc={<VersionLink agentVersion={this.getField(identity, 'agentVersion')} />} />
+        <Definition term={t('terms.version')} desc={<a href={'https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v' + process.env.REACT_APP_VERSION} className='link blue' target='_blank' rel='noopener noreferrer'>{process.env.REACT_APP_VERSION}</a>} />
       </DefinitionList>
     )
   }

--- a/src/status/NodeInfo.js
+++ b/src/status/NodeInfo.js
@@ -29,7 +29,7 @@ class NodeInfo extends React.Component {
       <DefinitionList>
         <Definition term={t('terms.peerId')} desc={this.getField(identity, 'id')} />
         <Definition term={t('terms.agent')} desc={<VersionLink agentVersion={this.getField(identity, 'agentVersion')} />} />
-        <Definition term={t('terms.version')} desc={<a href={'https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v' + process.env.REACT_APP_VERSION} className='link blue' target='_blank' rel='noopener noreferrer'>{process.env.REACT_APP_VERSION}</a>} />
+        <Definition term={t('terms.ui')} desc={<a href={'https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v' + process.env.REACT_APP_VERSION} className='link blue' target='_blank' rel='noopener noreferrer'>v{process.env.REACT_APP_VERSION}</a>} />
       </DefinitionList>
     )
   }


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1650.
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1649.

This PR ...
- Adds WebUI version number (linked to appropriate release page on GitHub) on both the nav (at widths wide enough for nav to appear at page left) and the Status screen
-  Tightens left-nav formatting to improve display for smaller 16x9 format screens (as identified in https://github.com/ipfs-shipyard/ipfs-webui/issues/1649#issuecomment-699055376), primarily to preserve display of version/revision/repo/bug-report links at nav bottom for 640+ high windows

**Big thanks to @bertrandfalguiere for raising these issues and PRing an initial fix!**

**Screenshot**
Mac Chrome, 660px high, new version on the right:
![image](https://user-images.githubusercontent.com/1507828/94871850-3e83b300-0408-11eb-9ef5-369401b9987c.png)



