### PR TITLE
fix: import / importing items count

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -296,6 +296,7 @@ const actions = () => ({
       }
 
       yield { entries, progress: 100 }
+      return entries
     } finally {
       await store.doFilesFetch()
     }

--- a/src/files/file-import-status/FileImportStatus.js
+++ b/src/files/file-import-status/FileImportStatus.js
@@ -13,37 +13,75 @@ import GlyphTick from '../../icons/GlyphTick'
 import GlyphCancel from '../../icons/GlyphCancel'
 import GlyphSmallCancel from '../../icons/GlyphSmallCancel'
 
-const File = (job, t) => {
-  const pathsByFolder = job.message.entries.reduce((prev, currentEntry) => {
-    const isFolder = currentEntry.path.includes('/')
-    if (!isFolder) {
-      return [...prev, currentEntry]
-    }
-
-    const baseFolder = currentEntry.path.split('/')[0]
-
-    const alreadyExistentBaseFolder = prev.find(previousPath => previousPath.path.startsWith(`${baseFolder}/`))
-
-    if (alreadyExistentBaseFolder) {
-      alreadyExistentBaseFolder.count = alreadyExistentBaseFolder.count + 1
-
-      return prev
-    }
-
-    return [...prev, { ...currentEntry, name: baseFolder, count: 1 }]
-  }, [])
-
-  return pathsByFolder.map(({ count, name, path, size, progress }) => (
-    <li className="flex w-100 bb b--light-gray items-center f6 charcoal" key={ path || name }>
-      { count ? <FolderIcon className='fileImportStatusIcon fill-aqua pa1'/> : <DocumentIcon className='fileImportStatusIcon fill-aqua pa1'/> }
-      <span className="fileImportStatusName truncate">{ name || path }</span>
+const Import = (job, t) =>
+  [...groupByPath(job.message.entries).values()].map(item => (
+    <li className="flex w-100 bb b--light-gray items-center f6 charcoal" key={item.path}>
+      {viewIcon(item)}
+      <span className="fileImportStatusName truncate">{item.path}</span>
       <span className='gray mh2'> |
-        { count && (<span> { t('filesImportStatus.count', { count }) } | </span>) }
-        <span className='ml2'>{ filesize(size) }</span>
+        { item.entries && (<span> { t('filesImportStatus.count', { count: item.entries.length }) } | </span>) }
+        <span className='ml2'>{ filesize(item.size) }</span>
       </span>
-      { job.status === 'Exit' && !job.result.ok ? <GlyphCancel className="dark-red w2 ph1" fill="currentColor"/> : <LoadingIndicator complete={ !progress }/> }
+      {viewImportStatus(job)}
     </li>
   ))
+
+const viewIcon = (entry) => entry.type === 'directory'
+  ? <FolderIcon className='fileImportStatusIcon fill-aqua pa1'/>
+  : <DocumentIcon className='fileImportStatusIcon fill-aqua pa1'/>
+
+const viewImportStatus = (job) => {
+  switch (job.status) {
+    case 'Pending': {
+      return (<LoadingIndicator />)
+    }
+    case 'Failed': {
+      return (<GlyphCancel className="dark-red w2 ph1" fill="currentColor"/>)
+    }
+    default: {
+      return (<LoadingIndicator complete={true}/>)
+    }
+  }
+}
+
+const groupByPath = (entries) => {
+  const groupedEntries = new Map()
+  for (const entry of entries) {
+    const name = baseDirectoryOf(entry)
+    if (name == null) {
+      groupedEntries.set(entry.path, { type: 'file', ...entry })
+    } else {
+      // add `/` to avoid collision with file names.
+      const directory = groupedEntries.get(`${name}/`)
+      if (directory) {
+        directory.entries.push(entry)
+        directory.size += entry.size
+      } else {
+        groupedEntries.set(`${name}/`, {
+          type: 'directory',
+          size: entry.size,
+          path: name,
+          entries: [entry]
+        })
+      }
+    }
+  }
+  return groupedEntries
+}
+
+/**
+ * @typedef {Object} Entry
+ * @property {string} path
+ * @property {size} number
+ */
+
+/**
+ * @param {Entry} entry
+ * @returns {string|null}
+ */
+const baseDirectoryOf = ({ path }) => {
+  const index = path.indexOf('/')
+  return index < 0 ? null : path.slice(0, index)
 }
 
 const LoadingIndicator = ({ complete }) => (
@@ -68,7 +106,8 @@ const FileImportStatus = ({ filesFinished, filesPending, filesErrors, doFilesCle
     return null
   }
 
-  const numberOfImportedFiles = !filesFinished.length ? 0 : filesFinished.reduce((prev, finishedFile) => prev + finishedFile?.state?.entries?.length, 0)
+  const numberOfPendingItems = filesPending.reduce((total, pending) => total + groupByPath(pending.message.entries).size, 0)
+  const numberOfImportedItems = filesFinished.reduce((total, finished) => total + groupByPath(finished.value).size, 0)
 
   return (
     <div className='fileImportStatus fixed bottom-1 w-100 flex justify-center' style={{ zIndex: 14, pointerEvents: 'none' }}>
@@ -76,8 +115,8 @@ const FileImportStatus = ({ filesFinished, filesPending, filesErrors, doFilesCle
         <div className="fileImportStatusButton pv2 ph3 relative flex items-center no-select pointer charcoal w-100 justify-between" style={{ background: '#F0F6FA' }}>
           <span>
             { filesPending.length
-              ? t('filesImportStatus.importing', { count: filesPending.length })
-              : t('filesImportStatus.imported', { count: numberOfImportedFiles })
+              ? t('filesImportStatus.importing', { count: numberOfPendingItems })
+              : t('filesImportStatus.imported', { count: numberOfImportedItems })
             }
           </span>
           <div className="flex items-center">
@@ -90,9 +129,9 @@ const FileImportStatus = ({ filesFinished, filesPending, filesErrors, doFilesCle
           </div>
         </div>
         <ul className='fileImportStatusRow pa0 ma0' aria-hidden={!expanded}>
-          { filesPending.map(file => File(file, t)) }
-          { sortedFilesFinished.map(file => File(file, t)) }
-          { filesErrors.map(file => File(file, t)) }
+          { filesPending.map(file => Import(file, t)) }
+          { sortedFilesFinished.map(file => Import(file, t)) }
+          { filesErrors.map(file => Import(file, t)) }
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This fixes https://github.com/ipfs-shipyard/ipfs-webui/issues/1659, I would like to figure out how to automate tests for that issue, but I also don't want to block release so submitting this now & will try to figure out how to test in the followup.

According to @jessicaschilling we expect that when you drop or select `n` files for importing it would show "Importing n items" and once import is done show "Imported n items", however if you drop / select a file and a directory of n files it should show "Importing 2 items" and later "Imported 2 items" (Unless you had more items imported prior).

However code seemed to count number of import tasks for showing "importing n items" and then counting number of total files for showing "Imported n items", so neither was correct. Additionally non-existing `state` field was accessed which lead to `NaN`.

This change factors out general logic of grouping by directory name used in the view and uses it to count both pending and imported item numbers.