### PR TITLE
docs: update release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,8 @@ You can read more on how we use Transifex and i18next in this app at [`docs/LOCA
 1. Wait for master to [build on CI](https://circleci.com/gh/ipfs-shipyard/ipfs-webui), and grab the CID produced from the tagged commit
 1. Add release notes to https://github.com/ipfs-shipyard/ipfs-webui/releases, use the tag and CID you created 
 1. Update the CID at projects that use ipfs-webui by submitting PR against below lines:
-   - js-ipfs: https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs/src/http/api/routes/webui.js#L8
+   - js-ipfs: https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-server/src/api/routes/webui.js#L8
    - go-ipfs: https://github.com/ipfs/go-ipfs/blob/master/core/corehttp/webui.go#L4
-   - ipfs-companion: https://github.com/ipfs-shipyard/ipfs-companion/blob/master/add-on/src/lib/precache.js#L15
    - ipfs-desktop: https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/package.json#L18
 
 ## Contribute


### PR DESCRIPTION
This PR updates post-release steps:

- removes the need for bumping CID in ipfs-companion (it now [automatically detects CID to preload](https://github.com/ipfs-shipyard/ipfs-companion/blob/master/add-on/src/lib/precache.js#L31-L37))
- updates path for js-ipfs (https://github.com/ipfs/js-ipfs/pull/3317)