### PR TITLE
feat: better left navbar response at varying heights

### DIFF
--- a/src/navigation/NavBar.css
+++ b/src/navigation/NavBar.css
@@ -12,7 +12,21 @@
   }
 }
 
-@media only screen and (max-height: 640px) {
+@media only screen and (min-height: 49em) and (min-width: 60em) {
+  .navbar-logo-vert {
+    padding-bottom: 1rem;
+  }
+  .navbar-item {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+  .navbar-footer {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+}
+
+@media only screen and (max-height: 40em) {
   .navbar-footer {
     display: none;
   }

--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -29,7 +29,7 @@ const NavLink = ({
   const anchorClass = classnames({
     'bg-white-10 navbar-item-active': active,
     'o-50 no-pointer-events': disabled
-  }, ['dib db-l pt2 pb3 pv2-l white no-underline f5 hover-bg-white-10 tc bb bw2 bw0-l b--navy'])
+  }, ['navbar-item dib db-l pt2 pb3 pv1-l white no-underline f5 hover-bg-white-10 tc bb bw2 bw0-l b--navy'])
   const svgClass = classnames({
     'o-100': active,
     'o-50': !active
@@ -61,9 +61,9 @@ export const NavBar = ({ t }) => {
     <div className='h-100 fixed-l flex flex-column justify-between' style={{ overflowY: 'auto', width: 'inherit' }}>
       <div className='flex flex-column'>
         <a href="#/welcome" role='menuitem' title={t('welcome:description')}>
-          <div className='pt3 pb1 pv2-l'>
-            <img className='center db-l dn pv1' style={{ height: 94 }} src={ipfsLogoTextVert} alt='' />
-            <img className='center db dn-l' style={{ height: 70 }} src={ipfsLogoTextHoriz} alt='' />
+          <div className='pt3 pb1 pb2-l'>
+            <img className='navbar-logo-vert center db-l dn pt3 pb1' style={{ height: 94 }} src={ipfsLogoTextVert} alt='' />
+            <img className='navbar-logo-horiz center db dn-l' style={{ height: 70 }} src={ipfsLogoTextHoriz} alt='' />
           </div>
         </a>
         <div className='db overflow-x-scroll overflow-x-hidden-l nowrap tc' role='menubar'>


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-desktop/issues/1668 (but requires release of webui).

- Makes room for Electron window furniture (top left) vis-a-vis logo when used in IPFS Desktop
- Maintains the 640px+ (aka 40em in our height system) behavior requirement outlined in https://github.com/ipfs-shipyard/ipfs-webui/pull/1654: preserves display of version/revision/repo/bug-report links at nav bottom for 640+ high windows
- Enhancement: Adds a "height breakpoint" for condensing left-nav elements at windows shorter than 49em (see screenshot)
- Behavior at different heights remains unchanged if window is narrower than 60em (aka width breakpoint for moving the nav to the top of the window)

Eyeballed as OK in Web UI in Mac Chrome, Firefox, and Safari. 

Gif demonstration (Mac Firefox): https://gateway.ipfs.io/ipfs/QmUiSXL2Gt1176ncuUjU8KaKuPYkWyXu3tMK2opU5BF5CZ

Quick screenshot for comparison (Desktop RC2 from [here](https://github.com/ipfs-shipyard/ipfs-desktop/issues/1661#issuecomment-704503195) on left, full-height Mac Chrome in middle, condensed-height Mac Chrome on right):
![image](https://user-images.githubusercontent.com/1507828/95271982-85085180-07fc-11eb-812d-81ee2046d71e.png)

@rafaelramalho19 may have tweaks for a cleaner approach, but as-is this doesn't substantially introduce complexity, and in return offers a cleaner left navbar experience overall.