### PR TITLE
fix: uppercase & standardize repo stats display

### DIFF
--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -17,8 +17,8 @@ function BarOption ({ children, title, isLink = false, className = '', ...etc })
 
   return (
     <div className={className} {...etc}>
-      <span className='nowrap db f4 navy'>{children}</span>
-      <span className={`db ttl ${isLink ? 'navy underline' : 'gray'}`}>{title}</span>
+      <span className='nowrap db f4 charcoal'>{children}</span>
+      <span className={`db ttu f6 montserrat fw4 ${isLink ? 'link' : 'charcoal-muted'}`}>{title}</span>
     </div>
   )
 }


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1677.

Improvements to the legends in the Files page repo stats box:
- Uppercases to account for noun-capitalized languages (e.g. German)
- Improves text contrast for better legibility
- Uses link-blue text for consistency in link behavior
- Changes font to Montserrat for visual consistency

**Screenshot** (Mac Chrome):
![image](https://user-images.githubusercontent.com/1507828/97224842-5516f300-1797-11eb-8bd3-4f2fa433dc18.png)

Note: In the longer term, would like to add hover underline for all links throughout UI, but that's a matter for a separate PR.