### PR TITLE
feat(peers): /dnsaddr/ support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16665,23 +16665,6 @@
         "process": "^0.11.10"
       }
     },
-    "global-dirs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
-      "dev": true,
-      "requires": {
-        "ini": "2.0.0"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-          "dev": true
-        }
-      }
-    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -16734,17 +16717,187 @@
           "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
           "dev": true
         },
+        "libp2p-crypto": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.0.tgz",
+          "integrity": "sha512-w4tduG32px1i6TwekYZBSvizZTvDdMReZkE4DhUkf9IQ8WSqSo98K+6IZaYYM6PzWd5arbcAQQcFCRalJu9Ytw==",
+          "requires": {
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
+            "node-forge": "^0.10.0",
+            "pem-jwk": "^2.0.0",
+            "protons": "^2.0.0",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.1.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
+          }
+        },
+        "merge-options": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+          "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+          "requires": {
+            "is-plain-obj": "^2.1.0"
+          }
+        },
+        "multibase": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
+          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          },
+          "dependencies": {
+            "web-encoding": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+              "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+              "requires": {
+                "@zxing/text-encoding": "0.9.0"
+              }
+            }
+          }
+        },
+        "multicodec": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.0.tgz",
+          "integrity": "sha512-7AYpK/avswOWvnqQ9/jOkQCS7Fp4aKxw5ojvn5gyK2VQTZz3YVXeLMzoIZDBy745JSfJMXkTS0ptnHci5Mt1mA==",
+          "requires": {
+            "uint8arrays": "1.1.0",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            },
+            "varint": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+            }
+          }
+        },
+        "multihashes": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.2.tgz",
+          "integrity": "sha512-AP4IoV/YzkNrfbQKZE3OMPibrmy350OmCd6cJkwyM8oExaXIlOY4UnOOVSQtAEuq/LR01XfXKCESidzZvSwHCQ==",
+          "requires": {
+            "multibase": "^3.1.0",
+            "uint8arrays": "^2.0.5",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "varint": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.0.tgz",
+          "integrity": "sha512-FMzLEQEu+y4AgFoboe6peXLDeIZzsjvbBhI/wufLEfNf/Ev917sB4GCjMLO7CP2D9CXT5sjxjoloEODJ/jgyKw==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "err-code": "^3.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^3.1.2",
+            "murmurhash3js-revisited": "^3.0.0",
+            "uint8arrays": "^2.0.5"
+          },
+          "dependencies": {
+            "err-code": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+              "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+            }
+          }
+        },
+        "p-queue": {
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+          "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+          "requires": {
+            "eventemitter3": "^4.0.4",
+            "p-timeout": "^3.2.0"
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
+        "protons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
+          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+          "requires": {
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
+          }
+        },
         "slash": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
           "dev": true
+        },
+        "uint8arrays": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
+          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          },
+          "dependencies": {
+            "web-encoding": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+              "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+              "requires": {
+                "@zxing/text-encoding": "0.9.0"
+              }
+            }
+          }
         }
       }
     },
@@ -18859,6 +19012,50 @@
             "uint8arrays": "^1.1.0"
           },
           "dependencies": {
+            "multihashes": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.2.tgz",
+              "integrity": "sha512-AP4IoV/YzkNrfbQKZE3OMPibrmy350OmCd6cJkwyM8oExaXIlOY4UnOOVSQtAEuq/LR01XfXKCESidzZvSwHCQ==",
+              "dev": true,
+              "requires": {
+                "multibase": "^3.1.0",
+                "uint8arrays": "^2.0.5",
+                "varint": "^6.0.0"
+              },
+              "dependencies": {
+                "uint8arrays": {
+                  "version": "2.1.3",
+                  "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.3.tgz",
+                  "integrity": "sha512-2h2Z2OIqzrhHmZTv9ViJVyZZreFkHRHeihh7SxLVY/nLUVJhU4ey/u74tWsgMR6hhMSO2g5rhKmdLQIg3lKiUQ==",
+                  "dev": true,
+                  "requires": {
+                    "multibase": "^4.0.1",
+                    "web-encoding": "^1.1.0"
+                  },
+                  "dependencies": {
+                    "multibase": {
+                      "version": "4.0.2",
+                      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.2.tgz",
+                      "integrity": "sha512-l0XMK4O5I9cCfxC0/UMDX/UxlIlrqkjEZQNG+ZUUrsGhnXWgFXgatYOQSONiR/lQGfBO463UyZkh3SiQBpjRIQ==",
+                      "dev": true,
+                      "requires": {
+                        "@multiformats/base-x": "^4.0.1",
+                        "web-encoding": "^1.1.0"
+                      }
+                    }
+                  }
+                },
+                "web-encoding": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+                  "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+                  "dev": true,
+                  "requires": {
+                    "@zxing/text-encoding": "0.9.0"
+                  }
+                }
+              }
+            },
             "uint8arrays": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
@@ -18868,39 +19065,12 @@
                 "multibase": "^3.0.0",
                 "web-encoding": "^1.0.2"
               }
-            }
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.0.tgz",
-          "integrity": "sha512-w4tduG32px1i6TwekYZBSvizZTvDdMReZkE4DhUkf9IQ8WSqSo98K+6IZaYYM6PzWd5arbcAQQcFCRalJu9Ytw==",
-          "dev": true,
-          "requires": {
-            "err-code": "^2.0.0",
-            "is-typedarray": "^1.0.0",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.1",
-            "node-forge": "^0.10.0",
-            "pem-jwk": "^2.0.0",
-            "protons": "^2.0.0",
-            "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.1.0",
-            "ursa-optional": "^0.10.1"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
-              "dev": true,
-              "requires": {
-                "multibase": "^3.0.0",
-                "web-encoding": "^1.0.2"
-              }
+            },
+            "varint": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+              "dev": true
             }
           }
         },
@@ -18914,9 +19084,9 @@
           }
         },
         "multibase": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
-          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
+          "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
           "dev": true,
           "requires": {
             "@multiformats/base-x": "^4.0.1",
@@ -18935,9 +19105,9 @@
           }
         },
         "multicodec": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.0.tgz",
-          "integrity": "sha512-7AYpK/avswOWvnqQ9/jOkQCS7Fp4aKxw5ojvn5gyK2VQTZz3YVXeLMzoIZDBy745JSfJMXkTS0ptnHci5Mt1mA==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.3.tgz",
+          "integrity": "sha512-0tOH2Gtio39uO41o+2xl9UhRkCWxU5ZmZSbFCh/OjGzkWJI8e6lkN/s4Mj1YfyWoBod+2+S3W+6wO6nhkwN8pA==",
           "dev": true,
           "requires": {
             "uint8arrays": "1.1.0",
@@ -18963,36 +19133,65 @@
           }
         },
         "multihashes": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.2.tgz",
-          "integrity": "sha512-AP4IoV/YzkNrfbQKZE3OMPibrmy350OmCd6cJkwyM8oExaXIlOY4UnOOVSQtAEuq/LR01XfXKCESidzZvSwHCQ==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
+          "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
           "dev": true,
           "requires": {
-            "multibase": "^3.1.0",
-            "uint8arrays": "^2.0.5",
-            "varint": "^6.0.0"
+            "multibase": "^4.0.1",
+            "uint8arrays": "^2.1.3",
+            "varint": "^5.0.2"
           },
           "dependencies": {
+            "multibase": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.2.tgz",
+              "integrity": "sha512-l0XMK4O5I9cCfxC0/UMDX/UxlIlrqkjEZQNG+ZUUrsGhnXWgFXgatYOQSONiR/lQGfBO463UyZkh3SiQBpjRIQ==",
+              "dev": true,
+              "requires": {
+                "@multiformats/base-x": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
+            "uint8arrays": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.3.tgz",
+              "integrity": "sha512-2h2Z2OIqzrhHmZTv9ViJVyZZreFkHRHeihh7SxLVY/nLUVJhU4ey/u74tWsgMR6hhMSO2g5rhKmdLQIg3lKiUQ==",
+              "dev": true,
+              "requires": {
+                "multibase": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
             "varint": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
               "dev": true
+            },
+            "web-encoding": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+              "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+              "dev": true,
+              "requires": {
+                "@zxing/text-encoding": "0.9.0"
+              }
             }
           }
         },
         "multihashing-async": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.0.tgz",
-          "integrity": "sha512-FMzLEQEu+y4AgFoboe6peXLDeIZzsjvbBhI/wufLEfNf/Ev917sB4GCjMLO7CP2D9CXT5sjxjoloEODJ/jgyKw==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
+          "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
           "dev": true,
           "requires": {
             "blakejs": "^1.1.0",
             "err-code": "^3.0.0",
             "js-sha3": "^0.8.0",
-            "multihashes": "^3.1.2",
+            "multihashes": "^4.0.1",
             "murmurhash3js-revisited": "^3.0.0",
-            "uint8arrays": "^2.0.5"
+            "uint8arrays": "^2.1.3"
           },
           "dependencies": {
             "err-code": {
@@ -19000,6 +19199,35 @@
               "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
               "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
               "dev": true
+            },
+            "multibase": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.2.tgz",
+              "integrity": "sha512-l0XMK4O5I9cCfxC0/UMDX/UxlIlrqkjEZQNG+ZUUrsGhnXWgFXgatYOQSONiR/lQGfBO463UyZkh3SiQBpjRIQ==",
+              "dev": true,
+              "requires": {
+                "@multiformats/base-x": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
+            "uint8arrays": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.3.tgz",
+              "integrity": "sha512-2h2Z2OIqzrhHmZTv9ViJVyZZreFkHRHeihh7SxLVY/nLUVJhU4ey/u74tWsgMR6hhMSO2g5rhKmdLQIg3lKiUQ==",
+              "dev": true,
+              "requires": {
+                "multibase": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
+            "web-encoding": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+              "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+              "dev": true,
+              "requires": {
+                "@zxing/text-encoding": "0.9.0"
+              }
             }
           }
         },
@@ -19033,27 +19261,6 @@
               "requires": {
                 "multibase": "^3.0.0",
                 "web-encoding": "^1.0.2"
-              }
-            }
-          }
-        },
-        "uint8arrays": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.2.tgz",
-          "integrity": "sha512-/VcLZbPMs/dk23u22IZlPWycfBxntpwrvISHQs93/OdRlUTnQw9Uzmzaoq7DgJAZl1SlP/kw+NhbjFAEED42rQ==",
-          "dev": true,
-          "requires": {
-            "multibase": "^3.0.0",
-            "web-encoding": "^1.0.5"
-          },
-          "dependencies": {
-            "web-encoding": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
-              "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
-              "dev": true,
-              "requires": {
-                "@zxing/text-encoding": "0.9.0"
               }
             }
           }
@@ -21528,6 +21735,14 @@
             }
           }
         },
+        "multiaddr-to-uri": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
+          "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
+          "requires": {
+            "multiaddr": "^7.2.1"
+          }
+        },
         "multibase": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
@@ -22202,6 +22417,21 @@
         "is-path-inside": "^3.0.2"
       },
       "dependencies": {
+        "global-dirs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+          "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+          "dev": true,
+          "requires": {
+            "ini": "2.0.0"
+          }
+        },
+        "ini": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+          "dev": true
+        },
         "is-path-inside": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
@@ -22232,10 +22462,52 @@
         "uint8arrays": "^2.0.5"
       },
       "dependencies": {
+        "cids": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.5.tgz",
+          "integrity": "sha512-i0V7tF2Jf78BKXyy2rpy1H/ozaJEP8b3Z7ZcHe9J86RRvJZ4e7daaJP3xwL09e14/Bl/mYX5WVc36fbQtjH7Sg==",
+          "requires": {
+            "multibase": "^3.0.1",
+            "multicodec": "^2.1.0",
+            "multihashes": "^3.1.0",
+            "uint8arrays": "^2.0.5"
+          }
+        },
         "iso-url": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.0.0.tgz",
           "integrity": "sha512-n/MsHgKOoHcFrhsxfbM3aaSdUujoFrrZ3537p3RW80AL7axL36acCseoMwIW4tNOl0n0SnkzNyVh4bREwmHoPQ=="
+        },
+        "multiaddr": {
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.1.2.tgz",
+          "integrity": "sha512-r13IzW8+Sv9zab9Gt8RPMIN2WkptIPq99EpAzg4IbJ/zTELhiEwXWr9bAmEatSCI4j/LSA6ESJzvz95JZ+ZYXQ==",
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0",
+            "dns-over-http-resolver": "^1.0.0",
+            "err-code": "^2.0.3",
+            "is-ip": "^3.1.0",
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.1.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            },
+            "varint": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+            }
+          }
         },
         "multibase": {
           "version": "3.1.1",
@@ -22244,6 +22516,26 @@
           "requires": {
             "@multiformats/base-x": "^4.0.1",
             "web-encoding": "^1.0.6"
+          }
+        },
+        "multicodec": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.0.tgz",
+          "integrity": "sha512-7AYpK/avswOWvnqQ9/jOkQCS7Fp4aKxw5ojvn5gyK2VQTZz3YVXeLMzoIZDBy745JSfJMXkTS0ptnHci5Mt1mA==",
+          "requires": {
+            "uint8arrays": "1.1.0",
+            "varint": "^6.0.0"
+          },
+          "dependencies": {
+            "uint8arrays": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+              "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+              "requires": {
+                "multibase": "^3.0.0",
+                "web-encoding": "^1.0.2"
+              }
+            }
           }
         },
         "multihashes": {
@@ -22271,12 +22563,9 @@
           "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
         },
         "web-encoding": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
-          "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
-          "requires": {
-            "@zxing/text-encoding": "0.9.0"
-          }
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.6.tgz",
+          "integrity": "sha512-26wEnRPEFAc5d5lmH1Q/DuvWEYsRF1D2alX2jlKpdmqv7cj+BbANL7Xlcl9r4s72Eg9kItZa9RWVbBMC9dMv4w=="
         }
       }
     },
@@ -23003,6 +23292,92 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "cids": {
+              "version": "0.8.3",
+              "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+              "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "class-is": "^1.1.0",
+                "multibase": "^1.0.0",
+                "multicodec": "^1.0.1",
+                "multihashes": "^1.0.1"
+              },
+              "dependencies": {
+                "multibase": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+                  "requires": {
+                    "base-x": "^3.0.8",
+                    "buffer": "^5.5.0"
+                  }
+                }
+              }
+            },
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              },
+              "dependencies": {
+                "multibase": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+                  "requires": {
+                    "base-x": "^3.0.8",
+                    "buffer": "^5.5.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multibase": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
         },
         "npm-run-path": {
           "version": "4.0.1",
@@ -26050,6 +26425,175 @@
         "peer-id": "^0.14.0"
       }
     },
+    "libp2p-crypto": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.1.tgz",
+      "integrity": "sha512-qrTxxvvDcnS/24Kcc5ngHxB8g4qexvVArE/k546+4mQwWUZvqw+JSEqlzWfdts5EMc2/Zzaq9CYl/t1fEyVL9g==",
+      "dev": true,
+      "requires": {
+        "err-code": "^2.0.0",
+        "is-typedarray": "^1.0.0",
+        "iso-random-stream": "^1.1.0",
+        "keypair": "^1.0.1",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
+        "node-forge": "^0.10.0",
+        "pem-jwk": "^2.0.0",
+        "protons": "^2.0.0",
+        "secp256k1": "^4.0.0",
+        "uint8arrays": "^1.1.0",
+        "ursa-optional": "^0.10.1"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
+          "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
+          "dev": true,
+          "requires": {
+            "@multiformats/base-x": "^4.0.1",
+            "web-encoding": "^1.0.6"
+          }
+        },
+        "multicodec": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.3.tgz",
+          "integrity": "sha512-0tOH2Gtio39uO41o+2xl9UhRkCWxU5ZmZSbFCh/OjGzkWJI8e6lkN/s4Mj1YfyWoBod+2+S3W+6wO6nhkwN8pA==",
+          "dev": true,
+          "requires": {
+            "uint8arrays": "1.1.0",
+            "varint": "^6.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
+          "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
+          "dev": true,
+          "requires": {
+            "multibase": "^4.0.1",
+            "uint8arrays": "^2.1.3",
+            "varint": "^5.0.2"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.2.tgz",
+              "integrity": "sha512-l0XMK4O5I9cCfxC0/UMDX/UxlIlrqkjEZQNG+ZUUrsGhnXWgFXgatYOQSONiR/lQGfBO463UyZkh3SiQBpjRIQ==",
+              "dev": true,
+              "requires": {
+                "@multiformats/base-x": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
+            "uint8arrays": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.3.tgz",
+              "integrity": "sha512-2h2Z2OIqzrhHmZTv9ViJVyZZreFkHRHeihh7SxLVY/nLUVJhU4ey/u74tWsgMR6hhMSO2g5rhKmdLQIg3lKiUQ==",
+              "dev": true,
+              "requires": {
+                "multibase": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
+            "varint": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+              "dev": true
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
+          "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "err-code": "^3.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^4.0.1",
+            "murmurhash3js-revisited": "^3.0.0",
+            "uint8arrays": "^2.1.3"
+          },
+          "dependencies": {
+            "err-code": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+              "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+              "dev": true
+            },
+            "multibase": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.2.tgz",
+              "integrity": "sha512-l0XMK4O5I9cCfxC0/UMDX/UxlIlrqkjEZQNG+ZUUrsGhnXWgFXgatYOQSONiR/lQGfBO463UyZkh3SiQBpjRIQ==",
+              "dev": true,
+              "requires": {
+                "@multiformats/base-x": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            },
+            "uint8arrays": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.3.tgz",
+              "integrity": "sha512-2h2Z2OIqzrhHmZTv9ViJVyZZreFkHRHeihh7SxLVY/nLUVJhU4ey/u74tWsgMR6hhMSO2g5rhKmdLQIg3lKiUQ==",
+              "dev": true,
+              "requires": {
+                "multibase": "^4.0.1",
+                "web-encoding": "^1.1.0"
+              }
+            }
+          }
+        },
+        "protons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
+          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
+          "dev": true,
+          "requires": {
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "varint": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+              "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+              "dev": true
+            }
+          }
+        },
+        "uint8arrays": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+          "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+          "dev": true,
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+          "dev": true
+        },
+        "web-encoding": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+          "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+          "dev": true,
+          "requires": {
+            "@zxing/text-encoding": "0.9.0"
+          }
+        }
+      }
+    },
     "libp2p-delegated-content-routing": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.9.0.tgz",
@@ -27118,6 +27662,12 @@
         "streaming-iterables": "^5.0.3"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -27127,11 +27677,102 @@
             "ms": "2.1.2"
           }
         },
+        "engine.io": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+          "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "base64id": "2.0.0",
+            "cookie": "~0.4.1",
+            "cors": "~2.8.5",
+            "debug": "~4.3.1",
+            "engine.io-parser": "~4.0.0",
+            "ws": "~7.4.2"
+          }
+        },
+        "engine.io-client": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.2.tgz",
+          "integrity": "sha512-1mwvwKYMa0AaCy+sPgvJ/SnKyO5MJZ1HEeXfA3Rm/KHkHGiYD5bQVq8QzvIrkI01FuVtOdZC5lWdRw1BGXB2NQ==",
+          "dev": true,
+          "requires": {
+            "base64-arraybuffer": "0.1.4",
+            "component-emitter": "~1.3.0",
+            "debug": "~4.3.1",
+            "engine.io-parser": "~4.0.1",
+            "has-cors": "1.1.0",
+            "parseqs": "0.0.6",
+            "parseuri": "0.0.6",
+            "ws": "~7.4.2",
+            "xmlhttprequest-ssl": "~1.5.4",
+            "yeast": "0.1.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+          "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+          "dev": true,
+          "requires": {
+            "base64-arraybuffer": "0.1.4"
+          }
+        },
         "err-code": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
           "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
           "dev": true
+        },
+        "socket.io-adapter": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+          "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+          "dev": true
+        },
+        "socket.io-client-next": {
+          "version": "npm:socket.io-client@3.1.3",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-3.1.3.tgz",
+          "integrity": "sha512-4sIGOGOmCg3AOgGi7EEr6ZkTZRkrXwub70bBB/F0JSkMOUFpA77WsL87o34DffQQ31PkbMUIadGOk+3tx1KGbw==",
+          "dev": true,
+          "requires": {
+            "@types/component-emitter": "^1.2.10",
+            "backo2": "~1.0.2",
+            "component-emitter": "~1.3.0",
+            "debug": "~4.3.1",
+            "engine.io-client": "~4.1.0",
+            "parseuri": "0.0.6",
+            "socket.io-parser": "~4.0.4"
+          }
+        },
+        "socket.io-next": {
+          "version": "npm:socket.io@3.1.2",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+          "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+          "dev": true,
+          "requires": {
+            "@types/cookie": "^0.4.0",
+            "@types/cors": "^2.8.8",
+            "@types/node": ">=10.0.0",
+            "accepts": "~1.3.4",
+            "base64id": "~2.0.0",
+            "debug": "~4.3.1",
+            "engine.io": "~4.1.0",
+            "socket.io-adapter": "~2.1.0",
+            "socket.io-parser": "~4.0.3"
+          }
+        },
+        "socket.io-parser": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+          "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+          "dev": true,
+          "requires": {
+            "@types/component-emitter": "^1.2.10",
+            "component-emitter": "~1.3.0",
+            "debug": "~4.3.1"
+          }
         }
       }
     },
@@ -27820,21 +28461,21 @@
       "integrity": "sha1-H/Q3xPc0sTjvfCztuk2IgMf1wtg="
     },
     "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.46.0"
       }
     },
     "mimic-fn": {
@@ -28111,77 +28752,13 @@
         "varint": "^5.0.0"
       },
       "dependencies": {
-        "cids": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.5.tgz",
-          "integrity": "sha512-i0V7tF2Jf78BKXyy2rpy1H/ozaJEP8b3Z7ZcHe9J86RRvJZ4e7daaJP3xwL09e14/Bl/mYX5WVc36fbQtjH7Sg==",
-          "requires": {
-            "multibase": "^3.0.1",
-            "multicodec": "^2.1.0",
-            "multihashes": "^3.1.0",
-            "uint8arrays": "^2.0.5"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
-              "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
-              "requires": {
-                "multibase": "^3.0.0",
-                "web-encoding": "^1.0.5"
-              }
-            }
-          }
-        },
         "multibase": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.1.tgz",
-          "integrity": "sha512-kkSd8jWGznDNEC2eDwtnvSGlZeTeEt0+oHieNWUhv8rIi8JU3voIUo02HpJBNOtgmtxT2CPwkElub7Y9kz3nrw==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
+          "integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
           "requires": {
             "@multiformats/base-x": "^4.0.1",
             "web-encoding": "^1.0.6"
-          }
-        },
-        "multicodec": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.0.tgz",
-          "integrity": "sha512-7AYpK/avswOWvnqQ9/jOkQCS7Fp4aKxw5ojvn5gyK2VQTZz3YVXeLMzoIZDBy745JSfJMXkTS0ptnHci5Mt1mA==",
-          "requires": {
-            "uint8arrays": "1.1.0",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "varint": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-            }
-          }
-        },
-        "multihashes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.1.tgz",
-          "integrity": "sha512-oF4BesRWbr5BbcRr1/QCDlZK+An8LWBPHVPYKt/foDpqNtXX/l0lm/rmAjI8dDYruPO90OaGcAWI3KS5vNJdNw==",
-          "requires": {
-            "multibase": "^3.1.0",
-            "uint8arrays": "^2.0.5",
-            "varint": "^6.0.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
-              "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
-              "requires": {
-                "multibase": "^3.0.0",
-                "web-encoding": "^1.0.5"
-              }
-            },
-            "varint": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-              "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-            }
           }
         },
         "uint8arrays": {
@@ -28194,9 +28771,12 @@
           }
         },
         "web-encoding": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.6.tgz",
-          "integrity": "sha512-26wEnRPEFAc5d5lmH1Q/DuvWEYsRF1D2alX2jlKpdmqv7cj+BbANL7Xlcl9r4s72Eg9kItZa9RWVbBMC9dMv4w=="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.0.tgz",
+          "integrity": "sha512-KzYonGdJnZB3qvhK8hKca5qXk/wp+hgwGNTY1TnqtF2CzDzpN8szOC3ejhX9+wbhCq3vQs/TjM8BykS1kor0lQ==",
+          "requires": {
+            "@zxing/text-encoding": "0.9.0"
+          }
         }
       }
     },
@@ -28381,6 +28961,24 @@
       "integrity": "sha512-gv4Bea+ga9QdXINurpkEqun3ap3vnB+WYoe4c8ddqUYEH7B2h6iD39RF8uVN7OwmSfMY3RDxkvBnoI4e2/vLXQ==",
       "requires": {
         "globalthis": "^1.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "native-url": {
@@ -28601,9 +29199,9 @@
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
     "node-notifier": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
-      "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz",
+      "integrity": "sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==",
       "optional": true,
       "requires": {
         "growly": "^1.3.0",
@@ -28659,9 +29257,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.60",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "nofilter": {
       "version": "1.0.4",
@@ -36279,151 +36877,6 @@
             "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
             "isarray": "2.0.1"
-          }
-        }
-      }
-    },
-    "socket.io-client-next": {
-      "version": "npm:socket.io-client@3.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-3.1.1.tgz",
-      "integrity": "sha512-BLgIuCjI7Sf3mDHunKddX9zKR/pbkP7IACM3sJS3jha+zJ6/pGKRV6Fz5XSBHCfUs9YzT8kYIqNwOOuFNLtnYA==",
-      "dev": true,
-      "requires": {
-        "@types/component-emitter": "^1.2.10",
-        "backo2": "~1.0.2",
-        "component-emitter": "~1.3.0",
-        "debug": "~4.3.1",
-        "engine.io-client": "~4.1.0",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~4.0.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "engine.io-client": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.1.tgz",
-          "integrity": "sha512-iYasV/EttP/2pLrdowe9G3zwlNIFhwny8VSIh+vPlMnYZqSzLsTzSLa9hFy015OrH1s4fzoYxeHjVkO8hSFKwg==",
-          "dev": true,
-          "requires": {
-            "base64-arraybuffer": "0.1.4",
-            "component-emitter": "~1.3.0",
-            "debug": "~4.3.1",
-            "engine.io-parser": "~4.0.1",
-            "has-cors": "1.1.0",
-            "parseqs": "0.0.6",
-            "parseuri": "0.0.6",
-            "ws": "~7.4.2",
-            "xmlhttprequest-ssl": "~1.5.4",
-            "yeast": "0.1.2"
-          }
-        },
-        "engine.io-parser": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
-          "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
-          "dev": true,
-          "requires": {
-            "base64-arraybuffer": "0.1.4"
-          }
-        },
-        "socket.io-parser": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-          "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
-          "dev": true,
-          "requires": {
-            "@types/component-emitter": "^1.2.10",
-            "component-emitter": "~1.3.0",
-            "debug": "~4.3.1"
-          }
-        }
-      }
-    },
-    "socket.io-next": {
-      "version": "npm:socket.io@3.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.1.tgz",
-      "integrity": "sha512-7cBWdsDC7bbyEF6WbBqffjizc/H4YF1wLdZoOzuYfo2uMNSFjJKuQ36t0H40o9B20DO6p+mSytEd92oP4S15bA==",
-      "dev": true,
-      "requires": {
-        "@types/cookie": "^0.4.0",
-        "@types/cors": "^2.8.8",
-        "@types/node": "^14.14.10",
-        "accepts": "~1.3.4",
-        "base64id": "~2.0.0",
-        "debug": "~4.3.1",
-        "engine.io": "~4.1.0",
-        "socket.io-adapter": "~2.1.0",
-        "socket.io-parser": "~4.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.14.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
-          "dev": true
-        },
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "engine.io": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
-          "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
-          "dev": true,
-          "requires": {
-            "accepts": "~1.3.4",
-            "base64id": "2.0.0",
-            "cookie": "~0.4.1",
-            "cors": "~2.8.5",
-            "debug": "~4.3.1",
-            "engine.io-parser": "~4.0.0",
-            "ws": "~7.4.2"
-          }
-        },
-        "engine.io-parser": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
-          "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
-          "dev": true,
-          "requires": {
-            "base64-arraybuffer": "0.1.4"
-          }
-        },
-        "socket.io-adapter": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
-          "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
-          "dev": true
-        },
-        "socket.io-parser": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-          "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
-          "dev": true,
-          "requires": {
-            "@types/component-emitter": "^1.2.10",
-            "component-emitter": "~1.3.0",
-            "debug": "~4.3.1"
           }
         }
       }

--- a/src/components/address/Address.js
+++ b/src/components/address/Address.js
@@ -4,6 +4,9 @@ import Multiaddr from 'multiaddr'
 const Address = ({ value }) => {
   if (!value) return null
 
+  // future-proofing interop for multiaddr > 8.x
+  value = value.buffer || value
+
   const ma = Multiaddr(value)
   const protos = ma.protoNames().concat(['ipfs', 'p2p'])
   const parts = ma.toString().split('/')


### PR DESCRIPTION
This PR Closes #1593  and closes #1674


## TODO

- [x] support connecting to `/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN`
- [x] switch to release version of `is-ipfs` with https://github.com/ipfs-shipyard/is-ipfs/pull/35
- [x] support `/quic` multiaddrs
- [x] fix tests – https://github.com/Gozala/web-encoding/issues/10