### PR TITLE
feat: separate CLI Tutor Mode helptext

### DIFF
--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -30,8 +30,7 @@
     "unselectAll": "Unselect all"
   },
   "cliModal": {
-    "description": "Paste the following into your terminal to do this task in IPFS via the command line. Remember that you'll need to replace placeholders with your specific parameters.",
-    "extraNotes": "If you've made changes to the config in this page's code editor that you'd like to save, click the download icon next to the copy button to download it as a JSON file."
+    "description": "Paste the following into your terminal to do this task in IPFS via the command line. Remember that you'll need to replace placeholders with your specific parameters."
   },
   "nav": {
     "bugsLink": "Report a bug",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -20,7 +20,7 @@
     "share": "Share link"
   },
   "cliModal": {
-    "extraNotes": "This command will only pin/unpin this item's CID to your local node. If you want to persist it with a remote pinning service, consult that service's documentation to learn how."
+    "extraNotes": "This command is only for local pinning/unpinning. If you want to use a remote pinning service, consult that service's documentation to learn how to pin/unpin from the command line."
   },
   "shareModal": {
     "title": "Share files",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -20,7 +20,7 @@
     "share": "Share link"
   },
   "cliModal": {
-    "extraNotes": "This command is only for local pinning/unpinning. If you want to use a remote pinning service, consult that service's documentation to learn how to pin/unpin from the command line."
+    "extraNotesPinning": "This command is only for local pinning/unpinning. If you want to use a remote pinning service, consult that service's documentation to learn how to pin/unpin from the command line."
   },
   "shareModal": {
     "title": "Share files",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -19,6 +19,9 @@
     "copyHash": "Copy CID",
     "share": "Share link"
   },
+  "cliModal": {
+    "extraNotes": "This command will only pin this item's CID to your local node. If you want to persist it with a remote pinning service, consult that service's CLI documentation to learn how."
+  },
   "shareModal": {
     "title": "Share files",
     "description": "Copy the link below and share it with your friends."

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -20,7 +20,7 @@
     "share": "Share link"
   },
   "cliModal": {
-    "extraNotes": "This command will only pin this item's CID to your local node. If you want to persist it with a remote pinning service, consult that service's CLI documentation to learn how."
+    "extraNotes": "This command will only pin/unpin this item's CID to your local node. If you want to persist it with a remote pinning service, consult that service's documentation to learn how."
   },
   "shareModal": {
     "title": "Share files",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -20,7 +20,7 @@
   "apiDescription": "<0>If your node is configured with a <1>custom API address</1>, including a port other than the default 5001, enter it here.</0>",
   "cliDescription": "<0>Enable this option to display a \"view code\" <1></1> icon next to common IPFS commands. Clicking it opens a modal with that command's CLI code, so you can paste it into the IPFS command-line interface in your terminal.</0>",
   "cliModal": {
-    "extraNotes": "If you've made changes to the config in this page's code editor that you'd like to save, click the download icon next to the copy button to download it as a JSON file."
+    "extraNotesJsonConfig": "If you've made changes to the config in this page's code editor that you'd like to save, click the download icon next to the copy button to download it as a JSON file."
   },
   "pinningModal": {
     "title": "Select a pinning service provider.",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -19,6 +19,9 @@
   },
   "apiDescription": "<0>If your node is configured with a <1>custom API address</1>, including a port other than the default 5001, enter it here.</0>",
   "cliDescription": "<0>Enable this option to display a \"view code\" <1></1> icon next to common IPFS commands. Clicking it opens a modal with that command's CLI code, so you can paste it into the IPFS command-line interface in your terminal.</0>",
+  "cliModal": {
+    "extraNotes": "If you've made changes to the config in this page's code editor that you'd like to save, click the download icon next to the copy button to download it as a JSON file."
+  },
   "pinningModal": {
     "title": "Select a pinning service provider.",
     "description": "Don’t see your pinning service provider? <1>Add a custom one.<1>"

--- a/src/bundles/files/consts.js
+++ b/src/bundles/files/consts.js
@@ -85,6 +85,10 @@ export const cliCmdKeys = {
   ADD_NEW_PEER: 'addNewPeer'
 }
 
+export const cliCmdPrefixes = {
+  PIN_OBJECT: 'ipfs pin'
+}
+
 export const cliCommandList = {
   [cliCmdKeys.UPDATE_IPFS_CONFIG]: () => 'ipfs config replace <path-to-settings.json>',
   /**
@@ -99,7 +103,7 @@ export const cliCommandList = {
    * @param {string} cid
    * @param {string} op
    */
-  [cliCmdKeys.PIN_OBJECT]: (cid, op) => `ipfs pin ${op} ${cid}`,
+  [cliCmdKeys.PIN_OBJECT]: (cid, op) => `${cliCmdPrefixes.PIN_OBJECT} ${op} ${cid}`,
   /**
    * @param {string} filePath
    * @param {string} fileName

--- a/src/components/cli-tutor-mode/CliTutorMode.js
+++ b/src/components/cli-tutor-mode/CliTutorMode.js
@@ -10,6 +10,7 @@ import Overlay from '../overlay/Overlay'
 import Shell from '../shell/Shell'
 import StrokeDownload from '../../icons/StrokeDownload'
 import { cliCmdKeys, cliCommandList } from '../../bundles/files/consts'
+import { pin } from 'ipfs/src/core/components'
 
 export const CliTutorialModal = ({ command, t, onLeave, className, downloadConfig, ...props }) => {
   const onClickCopyToClipboard = (cmd) => {

--- a/src/components/cli-tutor-mode/CliTutorMode.js
+++ b/src/components/cli-tutor-mode/CliTutorMode.js
@@ -10,7 +10,6 @@ import Overlay from '../overlay/Overlay'
 import Shell from '../shell/Shell'
 import StrokeDownload from '../../icons/StrokeDownload'
 import { cliCmdKeys, cliCommandList } from '../../bundles/files/consts'
-import { pin } from 'ipfs/src/core/components'
 
 export const CliTutorialModal = ({ command, t, onLeave, className, downloadConfig, ...props }) => {
   const onClickCopyToClipboard = (cmd) => {

--- a/src/components/cli-tutor-mode/CliTutorMode.js
+++ b/src/components/cli-tutor-mode/CliTutorMode.js
@@ -9,7 +9,7 @@ import Button from '../button/Button'
 import Overlay from '../overlay/Overlay'
 import Shell from '../shell/Shell'
 import StrokeDownload from '../../icons/StrokeDownload'
-import { cliCmdKeys, cliCommandList } from '../../bundles/files/consts'
+import { cliCmdKeys, cliCommandList, cliCmdPrefixes } from '../../bundles/files/consts'
 
 export const CliTutorialModal = ({ command, t, onLeave, className, downloadConfig, ...props }) => {
   const onClickCopyToClipboard = (cmd) => {
@@ -26,7 +26,7 @@ export const CliTutorialModal = ({ command, t, onLeave, className, downloadConfi
         </p>
         <p className='charcoal-muted w-90 center'>
           { command && command === cliCommandList[cliCmdKeys.UPDATE_IPFS_CONFIG]() ? t('settings:cliModal.extraNotes') : ''}
-          { command && command === cliCommandList[cliCmdKeys.PIN_OBJECT]() ? t('files:cliModal.extraNotes') : ''}
+          { command && command.startsWith(cliCmdPrefixes.PIN_OBJECT) ? t('files:cliModal.extraNotes') : ''}
         </p>
         <div>
           <Shell className='tl' title="Shell">

--- a/src/components/cli-tutor-mode/CliTutorMode.js
+++ b/src/components/cli-tutor-mode/CliTutorMode.js
@@ -25,8 +25,8 @@ export const CliTutorialModal = ({ command, t, onLeave, className, downloadConfi
           {t('app:cliModal.description')}
         </p>
         <p className='charcoal-muted w-90 center'>
-          { command && command === cliCommandList[cliCmdKeys.UPDATE_IPFS_CONFIG]() ? t('settings:cliModal.extraNotes') : ''}
-          { command && command.startsWith(cliCmdPrefixes.PIN_OBJECT) ? t('files:cliModal.extraNotes') : ''}
+          { command && command === cliCommandList[cliCmdKeys.UPDATE_IPFS_CONFIG]() ? t('settings:cliModal.extraNotesJsonConfig') : ''}
+          { command && command.startsWith(cliCmdPrefixes.PIN_OBJECT) ? t('files:cliModal.extraNotesPinning') : ''}
         </p>
         <div>
           <Shell className='tl' title="Shell">

--- a/src/components/cli-tutor-mode/CliTutorMode.js
+++ b/src/components/cli-tutor-mode/CliTutorMode.js
@@ -25,7 +25,8 @@ export const CliTutorialModal = ({ command, t, onLeave, className, downloadConfi
           {t('app:cliModal.description')}
         </p>
         <p className='charcoal-muted w-90 center'>
-          { command && command === cliCommandList[cliCmdKeys.UPDATE_IPFS_CONFIG]() ? t('app:cliModal.extraNotes') : ''}
+          { command && command === cliCommandList[cliCmdKeys.UPDATE_IPFS_CONFIG]() ? t('settings:cliModal.extraNotes') : ''}
+          { command && command === cliCommandList[cliCmdKeys.PIN_OBJECT]() ? t('files:cliModal.extraNotes') : ''}
         </p>
         <div>
           <Shell className='tl' title="Shell">


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1686.

This PR separates out the i18n key `cliModal.extraNotes` so we can display different CLI Tutor Mode modal helptext in different situations:
- "IPFS Config" modal (already existed)
- "Set Pinning" command in Files screen context menu (new in this PR)

**To do:**
The i18n keys are split out, but I'm missing something that's probably obvious in terms of getting helptext to display when a tutor-mode modal is invoked from the context menu. @lidel or @rafaelramalho19, do you mind a quick look if you get the chance? 🙏 