### PR TITLE
feat: update Settings screen react-joyride for pinning services & tutor mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17252,9 +17252,9 @@
       }
     },
     "is-lite": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.6.0.tgz",
-      "integrity": "sha512-kJ16DuwOhtZg7RimZOf+zK86XOlPeNGGy20MhAfjN/zozuetECxOEtUDUAtzC5n21Yd2lVx6LqZvO1Zvd5DYhw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.0.tgz",
+      "integrity": "sha512-w/+euF/pELyAgLA6Pai8Vp3l2EMJygQx1wGkKf/Gu7/qTWxZvYFKrdVF4qbi9YdVmISzB/jE4Q7yO9alrHQa8A=="
     },
     "is-lower-case": {
       "version": "1.1.3",
@@ -22365,9 +22365,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "nested-property": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-1.0.4.tgz",
-      "integrity": "sha512-6fNIumJJUyP3rkB4FyVYCYpdW+PKUCaxRWRGLLf0kv/RKoG4mbTvInedA9x3zOyuOmOkGudKuAtPSI+dnhwj2g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
+      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
     },
     "next-tick": {
       "version": "1.0.0",
@@ -25764,6 +25764,27 @@
         "popper.js": "^1.16.0",
         "react-proptype-conditional-require": "^1.0.4",
         "tree-changes": "^0.5.1"
+      },
+      "dependencies": {
+        "is-lite": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.6.0.tgz",
+          "integrity": "sha512-kJ16DuwOhtZg7RimZOf+zK86XOlPeNGGy20MhAfjN/zozuetECxOEtUDUAtzC5n21Yd2lVx6LqZvO1Zvd5DYhw=="
+        },
+        "nested-property": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-1.0.1.tgz",
+          "integrity": "sha512-BnBBoo/8bBNRdAnJc7+m79oWk7dXwW1+vCesaEQhfDGVwXGLMvmI4NwYgLTW94R/x+R2s/yr2g/hB/4w/YSAvA=="
+        },
+        "tree-changes": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.5.1.tgz",
+          "integrity": "sha512-O873xzV2xRZ6N059Mn06QzmGKEE21LlvIPbsk2G+GS9ZX5OCur6PIwuuh0rWpAPvLWQZPj0XObyG27zZyLHUzw==",
+          "requires": {
+            "deep-diff": "^1.0.2",
+            "nested-property": "1.0.1"
+          }
+        }
       }
     },
     "react-focus-lock": {
@@ -25870,20 +25891,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-joyride": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.2.1.tgz",
-      "integrity": "sha512-2dcfuOPW1viQ7TxUxLajNJJiW+I4dh3dPaySuvc1uiWK1qC8uaxjhGwWSIdQitVw0j1/4NU7P2dPuB9d5umtlw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.3.0.tgz",
+      "integrity": "sha512-aY7+dgmBKbgGoMjN828qXnMAqeA6QvwvSWxj/fyvxIIIx0iu3wNVT/A5NZ0wHxiVDav+Df9YZuL412Q6C0l7gw==",
       "requires": {
         "deep-diff": "^1.0.2",
         "deepmerge": "^4.2.2",
         "exenv": "^1.2.2",
-        "is-lite": "^0.6.0",
-        "nested-property": "^1.0.2",
+        "is-lite": "^0.8.0",
+        "nested-property": "^4.0.0",
         "react-floater": "^0.7.2",
-        "react-is": "^16.12.0",
+        "react-is": "^16.13.1",
         "scroll": "^3.0.1",
         "scrollparent": "^2.0.1",
-        "tree-changes": "^0.5.1"
+        "tree-changes": "^0.6.1"
       }
     },
     "react-lifecycles-compat": {
@@ -29425,19 +29446,13 @@
       "dev": true
     },
     "tree-changes": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.5.1.tgz",
-      "integrity": "sha512-O873xzV2xRZ6N059Mn06QzmGKEE21LlvIPbsk2G+GS9ZX5OCur6PIwuuh0rWpAPvLWQZPj0XObyG27zZyLHUzw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.6.1.tgz",
+      "integrity": "sha512-J+eb7K2hHq8BexW71U5jPHr8RGtd7270plLBjz2a5ubsMpEhInH14k2kafHoCL+bncYS3ixGidToVwpzwC8kug==",
       "requires": {
-        "deep-diff": "^1.0.2",
-        "nested-property": "1.0.1"
-      },
-      "dependencies": {
-        "nested-property": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-1.0.1.tgz",
-          "integrity": "sha512-BnBBoo/8bBNRdAnJc7+m79oWk7dXwW1+vCesaEQhfDGVwXGLMvmI4NwYgLTW94R/x+R2s/yr2g/hB/4w/YSAvA=="
-        }
+        "fast-deep-equal": "^3.1.3",
+        "is-lite": "^0.8.0",
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "tree-kill": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-hook-form": "^6.0.6",
     "react-i18next": "^11.7.0",
     "react-identicons": "^1.2.4",
-    "react-joyride": "^2.1.1",
+    "react-joyride": "^2.3.0",
     "react-loadable": "^5.5.0",
     "react-overlays": "^2.1.1",
     "react-router-dom": "^5.2.0",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -117,15 +117,23 @@
       "paragraph1": "If you've configured your IPFS node with a custom API address, you can update your config file right here instead of editing the JSON by hand."
     },
     "step3": {
+      "title": "Pinning services",
+      "paragraph1": "<0>If you have accounts with third-party remote pinning services, add them here so you can pin/unpin items to those services directly from the Files screen. You can learn more about third-party pinning services in the <1>IPFS Docs</1>.</0>"
+    },
+    "step4": {
       "title": "Language selector",
       "paragraph1": "<0>You can change the language of the Web UI. If your preferred language isn't available, head over our project page in <1>Transifex</1> to help us translate!</0>"
     },
-    "step4": {
+    "step5": {
       "title": "Anonymous usage analytics",
       "paragraph1": "If you opt-in, you can help us make the Web UI better by sending anonymous usage analytics.",
       "paragraph2": "You're able to choose what data you send us and we won't be able to identify you, we value privacy above all else."
     },
-    "step5": {
+    "step6": {
+      "title": "CLI tutor mode",
+      "paragraph1": "Enable CLI tutor mode to see shortcuts to the command-line version of common IPFS commands — helpful if you're learning to use IPFS from the terminal, or if you just need a refresher."
+    },
+    "step7": {
       "title": "IPFS Config",
       "paragraph1": "You can change the config of your IPFS node right from Web UI!",
       "paragraph2": "Don't forget to restart the daemon to apply the changes."

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -113,17 +113,17 @@
       "paragraph2": "If you're running IPFS Desktop you'll have some specific settings for it too."
     },
     "step2": {
+      "title": "Custom API address",
+      "paragraph1": "If you've configured your IPFS node with a custom API address, you can update your config file right here instead of editing the JSON by hand."
+    },
+    "step3": {
       "title": "Language selector",
       "paragraph1": "<0>You can change the language of the Web UI. If your preferred language isn't available, head over our project page in <1>Transifex</1> to help us translate!</0>"
     },
-    "step3": {
+    "step4": {
       "title": "Anonymous usage analytics",
       "paragraph1": "If you opt-in, you can help us make the Web UI better by sending anonymous usage analytics.",
       "paragraph2": "You're able to choose what data you send us and we won't be able to identify you, we value privacy above all else."
-    },
-    "step4": {
-      "title": "Custom API address",
-      "paragraph1": "If you've configured your IPFS node with a custom API address, you can update your config file right here instead of editing the JSON by hand."
     },
     "step5": {
       "title": "IPFS Config",

--- a/src/components/language-selector/LanguageSelector.js
+++ b/src/components/language-selector/LanguageSelector.js
@@ -22,7 +22,7 @@ class LanguageSelector extends Component {
           <div className='pr4 flex items-center lh-copy charcoal f5 fw5' style={{ height: 40 }}>
             {getCurrentLanguage()}
           </div>
-          <Button className="tc" bg='bg-navy' minWidth={100} onClick={this.onLanguageEditOpen}>
+          <Button className="tc" bg='bg-teal' minWidth={100} onClick={this.onLanguageEditOpen}>
             {t('app:actions.change')}
           </Button>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@ body {
 }
 
 html, body, #root {
-  height: 100%;
+  min-height: 100%;
 }
 
 .appOverlay {

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -226,7 +226,7 @@ export const settingsTour = {
         <h2 className='f3 fw4'>{t('tour.step2.title')}</h2>
         <p className='tl f6'>{t('tour.step2.paragraph1')}</p>
       </div>,
-      placement: 'bottom',
+      placement: 'auto',
       target: '.joyride-settings-customapi'
     },
     {
@@ -237,7 +237,7 @@ export const settingsTour = {
           </p>
         </Trans>
       </div>,
-      placement: 'top',
+      placement: 'auto',
       target: '.joyride-settings-pinning'
     },
     {
@@ -249,7 +249,7 @@ export const settingsTour = {
           </p>
         </Trans>
       </div>,
-      placement: 'top',
+      placement: 'auto',
       target: '.joyride-settings-language'
     },
     {
@@ -258,7 +258,7 @@ export const settingsTour = {
         <p className='tl f6'>{t('tour.step5.paragraph1')}</p>
         <p className='tl f6'>{t('tour.step5.paragraph2')}</p>
       </div>,
-      placement: 'top',
+      placement: 'auto',
       target: '.joyride-settings-analytics'
     },
     {
@@ -266,7 +266,7 @@ export const settingsTour = {
         <h2 className='f3 fw4'>{t('tour.step6.title')}</h2>
         <p className='tl f6'>{t('tour.step6.paragraph1')}</p>
       </div>,
-      placement: 'top',
+      placement: 'auto',
       target: '.joyride-settings-tutormode'
     },
     {
@@ -276,7 +276,7 @@ export const settingsTour = {
         <p className='tl f6'>{t('tour.step7.paragraph2')}</p>
       </div>,
       locale: { last: t('tour.finish') },
-      placement: 'top',
+      placement: 'auto',
       target: '.joyride-settings-config'
     }
   ],

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -224,11 +224,7 @@ export const settingsTour = {
     {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step2.title')}</h2>
-        <Trans i18nKey='tour.step2.paragraph1' t={t}>
-          <p className='tl f6'>You can change the language of the Web UI.
-          If your preferred language isn't available, head over our project page in <a className='teal link' href='https://www.transifex.com/ipfs/ipfs-webui/translate/' rel='noopener noreferrer' target='_blank'>Transifex</a> to help us translate!
-          </p>
-        </Trans>
+        <p className='tl f6'>{t('tour.step2.paragraph1')}</p>
       </div>,
       placement: 'bottom',
       target: '.joyride-settings-customapi'
@@ -236,25 +232,49 @@ export const settingsTour = {
     {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step3.title')}</h2>
-        <p className='tl f6'>{t('tour.step3.paragraph1')}</p>
-        <p className='tl f6'>{t('tour.step3.paragraph2')}</p>
+        <Trans i18nKey='tour.step3.paragraph1' t={t}>
+          <p className='tl f6'>You can change the language of the Web UI.
+          If your preferred language isn't available, head over our project page in <a className='teal link' href='https://docs.ipfs.io/how-to/work-with-pinning-services' rel='noopener noreferrer' target='_blank'>docs</a> to help us translate!
+          </p>
+        </Trans>
       </div>,
-      placement: 'bottom',
-      target: '.joyride-settings-language'
+      placement: 'top',
+      target: '.joyride-settings-pinning'
     },
     {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step4.title')}</h2>
-        <p className='tl f6'>{t('tour.step4.paragraph1')}</p>
+        <Trans i18nKey='tour.step4.paragraph1' t={t}>
+          <p className='tl f6'>You can change the language of the Web UI.
+          If your preferred language isn't available, head over our project page in <a className='teal link' href='https://www.transifex.com/ipfs/ipfs-webui/translate/' rel='noopener noreferrer' target='_blank'>Transifex</a> to help us translate!
+          </p>
+        </Trans>
       </div>,
       placement: 'top',
-      target: '.joyride-settings-analytics'
+      target: '.joyride-settings-language'
     },
     {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step5.title')}</h2>
         <p className='tl f6'>{t('tour.step5.paragraph1')}</p>
         <p className='tl f6'>{t('tour.step5.paragraph2')}</p>
+      </div>,
+      placement: 'top',
+      target: '.joyride-settings-analytics'
+    },
+    {
+      content: <div className='montserrat charcoal'>
+        <h2 className='f3 fw4'>{t('tour.step6.title')}</h2>
+        <p className='tl f6'>{t('tour.step6.paragraph1')}</p>
+      </div>,
+      placement: 'top',
+      target: '.joyride-settings-tutormode'
+    },
+    {
+      content: <div className='montserrat charcoal'>
+        <h2 className='f3 fw4'>{t('tour.step7.title')}</h2>
+        <p className='tl f6'>{t('tour.step7.paragraph1')}</p>
+        <p className='tl f6'>{t('tour.step7.paragraph2')}</p>
       </div>,
       locale: { last: t('tour.finish') },
       placement: 'top',

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -231,7 +231,7 @@ export const settingsTour = {
         </Trans>
       </div>,
       placement: 'bottom',
-      target: '.joyride-settings-language'
+      target: '.joyride-settings-customapi'
     },
     {
       content: <div className='montserrat charcoal'>
@@ -240,7 +240,7 @@ export const settingsTour = {
         <p className='tl f6'>{t('tour.step3.paragraph2')}</p>
       </div>,
       placement: 'bottom',
-      target: '.joyride-settings-analytics'
+      target: '.joyride-settings-language'
     },
     {
       content: <div className='montserrat charcoal'>
@@ -248,7 +248,7 @@ export const settingsTour = {
         <p className='tl f6'>{t('tour.step4.paragraph1')}</p>
       </div>,
       placement: 'top',
-      target: '.joyride-settings-customapi'
+      target: '.joyride-settings-analytics'
     },
     {
       content: <div className='montserrat charcoal'>

--- a/src/lib/tours.js
+++ b/src/lib/tours.js
@@ -233,8 +233,7 @@ export const settingsTour = {
       content: <div className='montserrat charcoal'>
         <h2 className='f3 fw4'>{t('tour.step3.title')}</h2>
         <Trans i18nKey='tour.step3.paragraph1' t={t}>
-          <p className='tl f6'>You can change the language of the Web UI.
-          If your preferred language isn't available, head over our project page in <a className='teal link' href='https://docs.ipfs.io/how-to/work-with-pinning-services' rel='noopener noreferrer' target='_blank'>docs</a> to help us translate!
+          <p className='tl f6'>If you have accounts with third-party remote pinning services, add them here so you can pin/unpin items to those services directly from the Files screen. You can learn more about third-party pinning services in the <a className='teal link' href='https://docs.ipfs.io/how-to/work-with-pinning-services' rel='noopener noreferrer' target='_blank'>IPFS Docs</a>.
           </p>
         </Trans>
       </div>,

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -58,7 +58,7 @@ export const SettingsPage = ({
       </div>
     </Box>
 
-    <Box className='mb3 pa4-l pa2'>
+    <Box className='mb3 pa4-l pa2 joyride-settings-pinning'>
       <Title>{t('pinningServices.title')}</Title>
       {/* <Trans i18nKey='pinningServices.description'>
         <p className='ma0 mr2 lh-copy charcoal f6'>
@@ -86,7 +86,7 @@ export const SettingsPage = ({
 
     <Experiments t={t} />
 
-    <Box className='mb3 pa4-l pa2'>
+    <Box className='mb3 pa4-l pa2 joyride-settings-tutormode'>
       <div className='charcoal'>
         <Title>{t('cliTutorMode')}</Title>
         <Checkbox className='dib' onChange={doToggleCliTutorMode} checked={isCliTutorModeEnabled}

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -98,47 +98,49 @@ export const SettingsPage = ({
     </Box>
 
     { isIpfsConnected &&
-    (<Box className='mb3 pa4-l pa2 joyride-settings-config'>
-      <Title>{t('config')}</Title>
-      <div className='flex pb3'>
-        <div className='flex-auto'>
-          <div className='mw7'>
-            <SettingsInfo
-              t={t}
-              tReady={tReady}
-              config={config}
-              isIpfsConnected={isIpfsConnected}
-              isConfigBlocked={isConfigBlocked}
-              isLoading={isLoading}
-              hasExternalChanges={hasExternalChanges}
-              hasSaveFailed={hasSaveFailed}
-              hasSaveSucceded={hasSaveSucceded} />
+    (<Box className='mb3 pa4-l pa2'>
+      <div className='joyride-settings-config'>
+        <Title>{t('config')}</Title>
+        <div className='flex pb3'>
+          <div className='flex-auto'>
+            <div className='mw7'>
+              <SettingsInfo
+                t={t}
+                tReady={tReady}
+                config={config}
+                isIpfsConnected={isIpfsConnected}
+                isConfigBlocked={isConfigBlocked}
+                isLoading={isLoading}
+                hasExternalChanges={hasExternalChanges}
+                hasSaveFailed={hasSaveFailed}
+                hasSaveSucceded={hasSaveSucceded} />
+            </div>
           </div>
+          { config ? (
+            <div className='flex flex-column justify-center flex-row-l items-center-l'>
+              <CliTutorMode showIcon={true} config={config} t={t} command={command}/>
+              <Button
+                minWidth={100}
+                height={40}
+                bg='bg-charcoal'
+                className='tc'
+                disabled={isSaving || (!hasLocalChanges && !hasExternalChanges)}
+                onClick={onReset}>
+                {t('app:actions.reset')}
+              </Button>
+              <SaveButton
+                t={t}
+                tReady={tReady}
+                hasErrors={hasErrors}
+                hasSaveFailed={hasSaveFailed}
+                hasSaveSucceded={hasSaveSucceded}
+                hasLocalChanges={hasLocalChanges}
+                hasExternalChanges={hasExternalChanges}
+                isSaving={isSaving}
+                onClick={onSave} />
+            </div>
+          ) : null }
         </div>
-        { config ? (
-          <div className='flex flex-column justify-center flex-row-l items-center-l'>
-            <CliTutorMode showIcon={true} config={config} t={t} command={command}/>
-            <Button
-              minWidth={100}
-              height={40}
-              bg='bg-charcoal'
-              className='tc'
-              disabled={isSaving || (!hasLocalChanges && !hasExternalChanges)}
-              onClick={onReset}>
-              {t('app:actions.reset')}
-            </Button>
-            <SaveButton
-              t={t}
-              tReady={tReady}
-              hasErrors={hasErrors}
-              hasSaveFailed={hasSaveFailed}
-              hasSaveSucceded={hasSaveSucceded}
-              hasLocalChanges={hasLocalChanges}
-              hasExternalChanges={hasExternalChanges}
-              isSaving={isSaving}
-              onClick={onSave} />
-          </div>
-        ) : null }
       </div>
       { config ? (
         <JsonEditor


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-webui/issues/1514.

**This PR updates the react-joyride tour boxes on the Settings screen to bring this screen up to date for pinning service integration.**

### Done
- [x] Add a step for pinning services
- [x] Add a step for CLI tutor mode
- [x] Rearrange steps so they appear in the correct order (we rearranged Settings screen as part of pinning service integration)
- [x] Update react-joyride to latest release
- [x] Fix spotlighting scroll issue from below screenshot (done in https://github.com/ipfs-shipyard/ipfs-webui/pull/1701/commits/00d6401fc0a12abeedd9535df3f62cc10d81f684)

![image](https://user-images.githubusercontent.com/1507828/102543787-0b4cd980-4071-11eb-9aae-4ad2eabbfc59.png)

