### PR TITLE
fix(line-wrap): Fixed tooltips of file names

### DIFF
--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -48,8 +48,10 @@ export default class Tool extends React.Component {
         <div style={{
           bottom: '-10px',
           left: '50%',
-          transform: 'translate(-50%, 100%)'
-        }} className={`nowrap white z-max bg-navy-muted br2 pa1 f6 absolute ${(show && overflow) ? 'db' : 'dn'}`}>
+          transform: 'translate(-50%, 100%)',
+          wordWrap: 'break-word',
+          width: '100%'
+        }} className={`white z-max bg-navy-muted br2 pa1 f6 absolute ${(show && overflow) ? 'db' : 'dn'}`}>
           <span style={{
             width: '17px',
             height: '17px',

--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -81,7 +81,7 @@ const File = ({
     className += ' selected'
   }
 
-  const styles = { height: 55, overflow: 'hidden' }
+  const styles = { height: 55, overflow: 'visible' }
 
   if (focused || (selected && !translucent) || coloured || (isOver && canDrop)) {
     styles.backgroundColor = '#F0F6FA'


### PR DESCRIPTION
### Summary
This PR fixes the problem of displaying long file names when hovering the file.
- Set break-word property to tooltip.
- Changed overflow of rows to visible.
- Set tooltip width to not exceed the menus width.

Fixes: #1464

### Screenshot
![longFileName](https://user-images.githubusercontent.com/47010475/104194084-27019080-5421-11eb-8d71-e084cfb94c91.png)