### PR TITLE
fix: trim input of "Import from IPFS"

### DIFF
--- a/src/components/text-input-modal/TextInputModal.js
+++ b/src/components/text-input-modal/TextInputModal.js
@@ -34,7 +34,7 @@ class TextInputModal extends React.Component {
   }
 
   onChange = (event) => {
-    let val = event.target.value
+    let val = event.target.value.trim()
 
     if (this.props.onChange) {
       val = this.props.onChange(val)


### PR DESCRIPTION
# Description
This PR adds a default trim to `TextInputModal` and it should improve kind of user experiences.
Like below:
`before`:
![image](https://user-images.githubusercontent.com/16664654/106343500-af68a800-62e0-11eb-9384-1bb49ad9094a.png)


`after`:
![image](https://user-images.githubusercontent.com/16664654/106343115-cf976780-62de-11eb-9d8e-c69d1fdef2b0.png)
